### PR TITLE
Fix piping to jsonpath at command line 

### DIFF
--- a/bin/jsonpath
+++ b/bin/jsonpath
@@ -16,9 +16,7 @@ usage unless ARGV[0]
 jsonpath = JsonPath.new(ARGV[0])
 case ARGV[1]
 when nil #stdin
-  until STDIN.eof?
-    puts MultiJson.encode(jsonpath.on(MultiJson.decode(STDIN.readline)))
-  end
+  puts MultiJson.encode(jsonpath.on(MultiJson.decode(STDIN.read)))
 when String
   puts MultiJson.encode(jsonpath.on(MultiJson.decode(File.exist?(ARGV[1]) ? File.read(ARGV[1]) : ARGV[1])))
 end


### PR DESCRIPTION
I couldn't get piping from STDIN to work at the command line at when I checked the code I couldn't see how it could work because it seems to parse the input one line at a time. If the JSON spans multiple lines then it means the parser is only being applied to the JSON fragment from a particular line rather than the whole file. I can only think it was tested against a JSON input that was all on one line. 

This change fixes it to work with a multiline JSON file.
