### PR TITLE
Issue #21 - handle path where array index is greater than node size

### DIFF
--- a/lib/jsonpath/enumerable.rb
+++ b/lib/jsonpath/enumerable.rb
@@ -52,6 +52,9 @@ class JsonPath
                 next unless start_idx
                 end_idx = (array_args[1] && process_function_or_literal(array_args[1], -1) || (sub_path.count(':') == 0 ? start_idx : -1))
                 next unless end_idx
+                if start_idx == end_idx
+                  next unless start_idx < node.size 
+                end
               end
               start_idx %= node.size
               end_idx %= node.size

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -9,6 +9,10 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal 4, JsonPath.new('$.store.*').on(@object).first['book'].size
   end
 
+  def test_lookup_missing_element
+    assert_equal [], JsonPath.new('$.store.book[99].price').on(@object)
+  end
+
   def test_retrieve_all_authors
     assert_equal [
       @object['store']['book'][0]['author'],


### PR DESCRIPTION
Applying a jsonpath with an array index that doesn't exist should not match any elements.

I'm assuming that the response should be an empty result set, rather than an exception.

The patch only applies to paths that access a specific array index (ie. where start_idx == end_idx), not splices.
