### PR TITLE
support keys like $..book[?(@.price > 20)].price

### DIFF
--- a/lib/jsonpath/enumerable.rb
+++ b/lib/jsonpath/enumerable.rb
@@ -33,10 +33,10 @@ class JsonPath
             case node
             when Hash, Array
               (node.is_a?(Hash) ? node.keys : (0..node.size)).each do |e|
-                each(node, e, pos + 1) { |n|
-                  @_current_node = n
-                  yield n if process_function_or_literal(sub_path[1, sub_path.size - 1])
-                }
+                @_current_node = node[e]
+                if process_function_or_literal(sub_path[1, sub_path.size - 1])
+                  each(@_current_node, nil, pos + 1, &blk)
+                end
               end
             else
               yield node if process_function_or_literal(sub_path[1, sub_path.size - 1])

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -148,6 +148,10 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [@object['store']['book'][3]], JsonPath.new("$..book[?(@.price > 20)]").on(@object)
   end
 
+  def test_support_filter_by_childnode_value_and_select_child_key
+    assert_equal [23], JsonPath.new("$..book[?(@.price > 20)].price").on(@object)
+  end
+
   def example_object
     { "store"=> {
       "book" => [


### PR DESCRIPTION
support following filters:

```
$..book[?(@.price > 20)].price
```

This also fixes issue #11
