### PR TITLE
Path join feature

### DIFF
--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -8,7 +8,7 @@ class JsonPath
 
   PATH_ALL = '$..*'
 
-  attr_reader :path
+  attr_accessor :path
 
   def initialize(path, opts = nil)
     @opts = opts
@@ -52,6 +52,12 @@ class JsonPath
     end
   end
 
+  def join(join_path)
+    res = deep_clone
+    res.path += JsonPath.new(join_path).path
+    res
+  end
+
   def on(obj_or_str)
     enum_on(obj_or_str).to_a
   end
@@ -76,5 +82,9 @@ class JsonPath
   private
   def self.process_object(obj_or_str)
     obj_or_str.is_a?(String) ? MultiJson.decode(obj_or_str) : obj_or_str
+  end
+
+  def deep_clone
+    Marshal.load Marshal.dump(self)
   end
 end

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -94,6 +94,10 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal JsonPath.new('$..author').on(@object), JsonPath.on(@object, '$..author')
   end
 
+  def test_join
+    assert_equal JsonPath.new('$.store.book..author').on(@object), JsonPath.new('$.store').join('book..author').on(@object)
+  end
+
   def test_gsub
     @object2['store']['bicycle']['price'] += 10
     @object2['store']['book'][0]['price'] += 10


### PR DESCRIPTION
I'd like to propose a method to join paths, i.e. add/concatenate a path to an existing one:

```ruby
JsonPath.new("$.store").join("book..author").on(document)
# => JsonPath.new("$.store.book.author")
```

The use case i encounter quite often is: in, e.g. unit tests, i use some kind of base path, and i want to extend it multiple times and for different json documents. As i want to stay DRY i can only concatenate strings. However, a #join method provided by JsonPath would be IMHO much cleaner.

Thanks for your feedback/review.