### PR TITLE
Handle conditions within object child nodes

### DIFF
--- a/lib/jsonpath/enumerable.rb
+++ b/lib/jsonpath/enumerable.rb
@@ -31,12 +31,16 @@ class JsonPath
           when ??
             raise "Cannot use ?(...) unless eval is enabled" unless allow_eval?
             case node
-            when Hash, Array
-              (node.is_a?(Hash) ? node.keys : (0..node.size)).each do |e|
-                @_current_node = node[e]
+            when Array
+              node.size.times do |index|
+                @_current_node = node[index]
                 if process_function_or_literal(sub_path[1, sub_path.size - 1])
                   each(@_current_node, nil, pos + 1, &blk)
                 end
+              end
+            when Hash
+              if process_function_or_literal(sub_path[1, sub_path.size - 1])
+                each(@_current_node, nil, pos + 1, &blk)
               end
             else
               yield node if process_function_or_literal(sub_path[1, sub_path.size - 1])
@@ -54,7 +58,7 @@ class JsonPath
                 end_idx = (array_args[1] && process_function_or_literal(array_args[1], -1) || (sub_path.count(':') == 0 ? start_idx : -1))
                 next unless end_idx
                 if start_idx == end_idx
-                  next unless start_idx < node.size 
+                  next unless start_idx < node.size
                 end
               end
               start_idx %= node.size

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -155,7 +155,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [], JsonPath.on(object, "$..bicycle.tire[*]")
   end
 
-  def test_support_filter_by_childnode_value
+  def test_support_filter_by_array_childnode_value
     assert_equal [@object['store']['book'][3]], JsonPath.new("$..book[?(@.price > 20)]").on(@object)
   end
 
@@ -171,7 +171,18 @@ class TestJsonpath < MiniTest::Unit::TestCase
   def test_support_filter_by_childnode_value_over_childnode_and_select_child_key
     assert_equal ["Osennie Vizity"], JsonPath.new("$..book[?(@.written.year == 1996)].title").on(@object)
   end
-  
+
+  def test_support_filter_by_object_childnode_value
+    data = {
+      "data" => {
+        "type" => "users",
+        "id" => "123"
+      }
+    }
+    assert_equal [{"type"=>"users", "id"=>"123"}], JsonPath.new("$.data[?(@.type == 'users')]").on(data)
+    assert_equal []     , JsonPath.new("$.data[?(@.type == 'admins')]").on(data)
+  end
+
   def example_object
     { "store"=> {
       "book" => [


### PR DESCRIPTION
Hi! Thanks for the nice gem!
Here is the fix for an issue, I've detected couple hours ago: https://github.com/joshbuddy/jsonpath/issues/38

To make selector be correctly applied for a Hash object, it should be treated slightly differently than an array object: it should not reassign `@_current_node`, so current node should be still the same hash.
