### PR TITLE
Eliminating the use of eval step by step

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,6 @@ enum.any?{ |c| c == 'red' }
 # => true
 ```
 
-You can optionally prevent eval from being called on sub-expressions by passing in :allow_eval => false to the constructor.
-
 ### More examples
 
 For more usage examples and variations on paths, please visit the tests. There are some more complex ones as well.

--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -3,6 +3,7 @@ require 'multi_json'
 require 'jsonpath/proxy'
 require 'jsonpath/enumerable'
 require 'jsonpath/version'
+require 'jsonpath/parser'
 
 # JsonPath: initializes the class with a given JsonPath and parses that path
 # into a token array.

--- a/lib/jsonpath/enumerable.rb
+++ b/lib/jsonpath/enumerable.rb
@@ -122,32 +122,19 @@ class JsonPath
              @_current_node.methods.include?(identifiers[2].to_sym)
         exp_to_eval = exp.dup
         exp_to_eval[identifiers[0]] = identifiers[0].split('.').map do |el|
-          el == '@' ? '@_current_node' : "['#{el}']"
+          el == '@' ? '@' : "['#{el}']"
         end.join
-
+        p exp_to_eval
         begin
-          return instance_eval(exp_to_eval)
+          return JsonPath::Parser.new(@_current_node).parse(exp_to_eval)
+          # return instance_eval(exp_to_eval)
           # if eval failed because of bad arguments or missing methods
         rescue StandardError
           return default
         end
       end
-
-      # otherwise eval as is
-      # TODO: this eval is wrong, because hash accessor could be nil and nil
-      # cannot be compared with anything, for instance,
-      # @a_current_node['price'] - we can't be sure that 'price' are in every
-      # node, but it's only in several nodes I wrapped this eval into rescue
-      # returning false when error, but this eval should be refactored.
       begin
         JsonPath::Parser.new(@_current_node).parse(exp)
-        # proc do
-        #   $SAFE = 1
-        #   instance_eval(exp)
-        # end.call
-        # puts "WHAAAAAAAAT"
-        # p exp
-        # @_current_node['price'] < 23 && @_current_node['price'] > 9
       rescue
         false
       end

--- a/lib/jsonpath/enumerable.rb
+++ b/lib/jsonpath/enumerable.rb
@@ -80,6 +80,8 @@ class JsonPath
       when Array
         node.size.times do |index|
           @_current_node = node[index]
+          # exps = sub_path[1, sub_path.size - 1]
+          # if @_current_node.send("[#{exps.gsub(/@/, '@_current_node')}]")
           if process_function_or_literal(sub_path[1, sub_path.size - 1])
             each(@_current_node, nil, pos + 1, &blk)
           end
@@ -116,11 +118,6 @@ class JsonPath
       return nil unless allow_eval? && @_current_node
 
       identifiers = /@?((?<!\d)\.(?!\d)(\w+))+/.match(exp)
-      # puts JsonPath.on(@_current_node, "#{identifiers}") unless identifiers.nil? ||
-      #                                                           @_current_node
-      #                                                           .methods
-      #                                                           .include?(identifiers[2].to_sym)
-
       unless identifiers.nil? ||
              @_current_node.methods.include?(identifiers[2].to_sym)
         exp_to_eval = exp.dup
@@ -143,7 +140,10 @@ class JsonPath
       # node, but it's only in several nodes I wrapped this eval into rescue
       # returning false when error, but this eval should be refactored.
       begin
-        instance_eval(exp.gsub(/@/, '@_current_node'))
+        # instance_eval(exp.gsub(/@/, '@_current_node'))
+        puts "WHAAAAAAAAT"
+        p exp
+        @_current_node['price'] < 23 && @_current_node['price'] > 9
       rescue
         false
       end

--- a/lib/jsonpath/enumerable.rb
+++ b/lib/jsonpath/enumerable.rb
@@ -140,10 +140,14 @@ class JsonPath
       # node, but it's only in several nodes I wrapped this eval into rescue
       # returning false when error, but this eval should be refactored.
       begin
-        # instance_eval(exp.gsub(/@/, '@_current_node'))
-        puts "WHAAAAAAAAT"
-        p exp
-        @_current_node['price'] < 23 && @_current_node['price'] > 9
+        JsonPath::Parser.new(@_current_node).parse(exp)
+        # proc do
+        #   $SAFE = 1
+        #   instance_eval(exp)
+        # end.call
+        # puts "WHAAAAAAAAT"
+        # p exp
+        # @_current_node['price'] < 23 && @_current_node['price'] > 9
       rescue
         false
       end

--- a/lib/jsonpath/enumerable.rb
+++ b/lib/jsonpath/enumerable.rb
@@ -124,11 +124,8 @@ class JsonPath
         exp_to_eval[identifiers[0]] = identifiers[0].split('.').map do |el|
           el == '@' ? '@' : "['#{el}']"
         end.join
-        p exp_to_eval
         begin
           return JsonPath::Parser.new(@_current_node).parse(exp_to_eval)
-          # return instance_eval(exp_to_eval)
-          # if eval failed because of bad arguments or missing methods
         rescue StandardError
           return default
         end

--- a/lib/jsonpath/enumerable.rb
+++ b/lib/jsonpath/enumerable.rb
@@ -130,11 +130,7 @@ class JsonPath
           return default
         end
       end
-      begin
-        JsonPath::Parser.new(@_current_node).parse(exp)
-      rescue
-        false
-      end
+      JsonPath::Parser.new(@_current_node).parse(exp)
     end
   end
 end

--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -28,10 +28,21 @@ class JsonPath
           raise 'Could not process symbol.'
         end
       end
-      return false unless @_current_node.dig(*elements)
-      return true if operator.nil? && @_current_node.dig(*elements)
+      el = dig(elements, @_current_node)
+      return false unless el
+      return true if operator.nil? && el
       operand = operand.to_f if operand.to_i.to_s == operand || operand.to_f.to_s == operand
-      @_current_node.dig(*elements).send(operator.strip, operand)
+      el.send(operator.strip, operand)
+    end
+
+    private
+
+    # @TODO: Remove this once JsonPath no longer supports ruby versions below 2.3.
+    def dig(keys, hash)
+      return nil unless hash.key?(keys.first)
+      return hash.fetch(keys.first) if keys.size == 1
+      prev = keys.shift
+      dig(keys, hash.fetch(prev))
     end
   end
 end

--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -41,6 +41,8 @@ class JsonPath
         @_current_node[element] <= operand.strip.to_i
       when '=='
         @_current_node[element] == operand.strip.to_i
+      when '!='
+        @_current_node[element] != operand.strip.to_i
       end
     end
   end

--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -9,7 +9,6 @@ class JsonPath
 
     def parse(exp)
       exp = exp.gsub(/@/, '').gsub(/[\(\)]/, '')
-      p exp
       scanner = StringScanner.new(exp)
       elements = []
       until scanner.eos?
@@ -20,35 +19,19 @@ class JsonPath
           return @_current_node.send(sym.to_sym).send(op.to_sym, num.to_i)
         end
         if t = scanner.scan(/\['\w+'\]+/)
-          puts "t: #{t}"
-          element << t
+          elements << t.gsub(/\[|\]|'|\s+/, '')
         elsif t = scanner.scan(/\s+[<>=][<>=]?\s+?/)
           operator = t
-        elsif t = scanner.scan(/(\d+)?[.,]?(\d+)?/)
-          operand = t
+        elsif t = scanner.scan(/'?(\w+)?[.,]?(\w+)?'?/)
+          operand = t.delete("'").strip
         elsif t = scanner.scan(/.*/)
           raise 'Could not process symbol.'
         end
       end
-      puts "Element: #{sym}"
-      element = element.gsub(/\[|\]|'|\s+/, '') if element
-      return false unless @_current_node[element]
-      return true if operator.nil? && @_current_node.dig(element)
-      @_current_node.dig(element).send(operator.strip, operand.strip.to_i)
-      # case operator.strip
-      # when '<'
-      #   @_current_node[element] < operand.strip.to_i
-      # when '>'
-      #   @_current_node[element] > operand.strip.to_i
-      # when '>='
-      #   @_current_node[element] >= operand.strip.to_i
-      # when '<='
-      #   @_current_node[element] <= operand.strip.to_i
-      # when '=='
-      #   @_current_node[element] == operand.strip.to_i
-      # when '!='
-      #   @_current_node[element] != operand.strip.to_i
-      # end
+      return false unless @_current_node.dig(*elements)
+      return true if operator.nil? && @_current_node.dig(*elements)
+      operand = operand.to_f if operand.to_i.to_s == operand || operand.to_f.to_s == operand
+      @_current_node.dig(*elements).send(operator.strip, operand)
     end
   end
 end

--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -1,0 +1,47 @@
+require 'strscan'
+
+class JsonPath
+  # Parser parses and evaluates an expression passed to @_current_node.
+  class Parser
+    def initialize(node)
+      @_current_node = node
+    end
+
+    def parse(exp)
+      exp = exp.gsub(/@/, '').gsub(/[\(\)]/, '')
+      scanner = StringScanner.new(exp)
+      until scanner.eos?
+        if scanner.scan(/\./)
+          sym = scanner.scan(/\w+/)
+          op = scanner.scan(/./)
+          num = scanner.scan(/\d+/)
+          return @_current_node.send(sym.to_sym).send(op.to_sym, num.to_i)
+        end
+        if t = scanner.scan(/\['\w+'\]/)
+          element = t
+        elsif t = scanner.scan(/\s+[<>=][<>=]?\s+?/)
+          operator = t
+        elsif t = scanner.scan(/(\d+)?[.,]?(\d+)?/)
+          operand = t
+        elsif t = scanner.scan(/.*/)
+          raise 'Could not process symbol.'
+        end
+      end
+      element = element.gsub(/\[|\]|'|\s+/, '') if element
+      return false unless @_current_node[element]
+      return true if operator.nil? && @_current_node[element]
+      case operator.strip
+      when '<'
+        @_current_node[element] < operand.strip.to_i
+      when '>'
+        @_current_node[element] > operand.strip.to_i
+      when '>='
+        @_current_node[element] >= operand.strip.to_i
+      when '<='
+        @_current_node[element] <= operand.strip.to_i
+      when '=='
+        @_current_node[element] == operand.strip.to_i
+      end
+    end
+  end
+end

--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -9,7 +9,9 @@ class JsonPath
 
     def parse(exp)
       exp = exp.gsub(/@/, '').gsub(/[\(\)]/, '')
+      p exp
       scanner = StringScanner.new(exp)
+      elements = []
       until scanner.eos?
         if scanner.scan(/\./)
           sym = scanner.scan(/\w+/)
@@ -17,8 +19,9 @@ class JsonPath
           num = scanner.scan(/\d+/)
           return @_current_node.send(sym.to_sym).send(op.to_sym, num.to_i)
         end
-        if t = scanner.scan(/\['\w+'\]/)
-          element = t
+        if t = scanner.scan(/\['\w+'\]+/)
+          puts "t: #{t}"
+          element << t
         elsif t = scanner.scan(/\s+[<>=][<>=]?\s+?/)
           operator = t
         elsif t = scanner.scan(/(\d+)?[.,]?(\d+)?/)
@@ -27,23 +30,25 @@ class JsonPath
           raise 'Could not process symbol.'
         end
       end
+      puts "Element: #{sym}"
       element = element.gsub(/\[|\]|'|\s+/, '') if element
       return false unless @_current_node[element]
-      return true if operator.nil? && @_current_node[element]
-      case operator.strip
-      when '<'
-        @_current_node[element] < operand.strip.to_i
-      when '>'
-        @_current_node[element] > operand.strip.to_i
-      when '>='
-        @_current_node[element] >= operand.strip.to_i
-      when '<='
-        @_current_node[element] <= operand.strip.to_i
-      when '=='
-        @_current_node[element] == operand.strip.to_i
-      when '!='
-        @_current_node[element] != operand.strip.to_i
-      end
+      return true if operator.nil? && @_current_node.dig(element)
+      @_current_node.dig(element).send(operator.strip, operand.strip.to_i)
+      # case operator.strip
+      # when '<'
+      #   @_current_node[element] < operand.strip.to_i
+      # when '>'
+      #   @_current_node[element] > operand.strip.to_i
+      # when '>='
+      #   @_current_node[element] >= operand.strip.to_i
+      # when '<='
+      #   @_current_node[element] <= operand.strip.to_i
+      # when '=='
+      #   @_current_node[element] == operand.strip.to_i
+      # when '!='
+      #   @_current_node[element] != operand.strip.to_i
+      # end
     end
   end
 end

--- a/lib/jsonpath/version.rb
+++ b/lib/jsonpath/version.rb
@@ -1,3 +1,3 @@
 class JsonPath
-  VERSION = '0.7.2'.freeze
+  VERSION = '0.8.2'.freeze
 end

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -84,10 +84,6 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] == 13.0)]").on(@object)
   end
 
-  def test_no_eval
-    assert_equal [], JsonPath.new('$..book[(@.length-2)]', allow_eval: false).on(@object)
-  end
-
   def test_paths_with_underscores
     assert_equal [@object['store']['bicycle']['catalogue_number']], JsonPath.new('$.store.bicycle.catalogue_number').on(@object)
   end

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -109,7 +109,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
   end
 
   def test_counting
-    assert_equal 54, JsonPath.new('$..*').on(@object).to_a.size
+    assert_equal 57, JsonPath.new('$..*').on(@object).to_a.size
   end
 
   def test_space_in_path
@@ -255,6 +255,10 @@ class TestJsonpath < MiniTest::Unit::TestCase
       JsonPath.new("$.store._links").on(@object)
   end
 
+  def test_filter_support_include
+    #assert_equal true, JsonPath.new("$.store.book[(@.tags == 'asdf3')]").on(@object)
+    assert_equal true, JsonPath.new("$.store.book..tags[?(@ == 'asdf')]").on(@object)
+  end
 
   def example_object
     { 'store' => {
@@ -262,7 +266,8 @@ class TestJsonpath < MiniTest::Unit::TestCase
         { 'category' => 'reference',
           'author' => 'Nigel Rees',
           'title' => 'Sayings of the Century',
-          'price' => 9 },
+          'price' => 9,
+          'tags' => ['asdf', 'asdf2']},
         { 'category' => 'fiction',
           'author' => 'Evelyn Waugh',
           'title' => 'Sword of Honour',

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -64,21 +64,21 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [@object['store']['book'][3]], JsonPath.new("$..book[?(@['price'] > 20)]").on(@object)
   end
 
-  # def test_or_operator
-  #   assert_equal [@object['store']['book'][1], @object['store']['book'][3]], JsonPath.new("$..book[?(@['price'] == 13 || @['price'] == 23)]").on(@object)
-  # end
+  def test_or_operator
+    assert_equal [@object['store']['book'][1], @object['store']['book'][3]], JsonPath.new("$..book[?(@['price'] == 13 || @['price'] == 23)]").on(@object)
+  end
 
-  # def test_and_operator
-  #   assert_equal [], JsonPath.new("$..book[?(@['price'] == 13 && @['price'] == 23)]").on(@object)
-  # end
+  def test_and_operator
+    assert_equal [], JsonPath.new("$..book[?(@['price'] == 13 && @['price'] == 23)]").on(@object)
+  end
 
-  # def test_and_operator_with_more_results
-  #   assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] < 23 && @['price'] > 9)]").on(@object)
-  # end
+  def test_and_operator_with_more_results
+    assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] < 23 && @['price'] > 9)]").on(@object)
+  end
 
-  # def test_eval_with_floating_point
-  #   assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] < 23.0 && @['price'] > 9.0)]").on(@object)
-  # end
+  def test_eval_with_floating_point
+    assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] < 23.0 && @['price'] > 9.0)]").on(@object)
+  end
 
   def test_eval_with_floating_point
     assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] == 13.0)]").on(@object)

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -64,20 +64,24 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [@object['store']['book'][3]], JsonPath.new("$..book[?(@['price'] > 20)]").on(@object)
   end
 
-  def test_or_operator
-    assert_equal [@object['store']['book'][1], @object['store']['book'][3]], JsonPath.new("$..book[?(@['price'] == 13 || @['price'] == 23)]").on(@object)
-  end
+  # def test_or_operator
+  #   assert_equal [@object['store']['book'][1], @object['store']['book'][3]], JsonPath.new("$..book[?(@['price'] == 13 || @['price'] == 23)]").on(@object)
+  # end
 
-  def test_and_operator
-    assert_equal [], JsonPath.new("$..book[?(@['price'] == 13 && @['price'] == 23)]").on(@object)
-  end
+  # def test_and_operator
+  #   assert_equal [], JsonPath.new("$..book[?(@['price'] == 13 && @['price'] == 23)]").on(@object)
+  # end
 
-  def test_and_operator_with_more_results
-    assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] < 23 && @['price'] > 9)]").on(@object)
-  end
+  # def test_and_operator_with_more_results
+  #   assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] < 23 && @['price'] > 9)]").on(@object)
+  # end
+
+  # def test_eval_with_floating_point
+  #   assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] < 23.0 && @['price'] > 9.0)]").on(@object)
+  # end
 
   def test_eval_with_floating_point
-    assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] < 23.0 && @['price'] > 9.0)]").on(@object)
+    assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] == 13.0)]").on(@object)
   end
 
   def test_no_eval
@@ -255,10 +259,10 @@ class TestJsonpath < MiniTest::Unit::TestCase
       JsonPath.new("$.store._links").on(@object)
   end
 
-  def test_filter_support_include
-    #assert_equal true, JsonPath.new("$.store.book[(@.tags == 'asdf3')]").on(@object)
-    assert_equal true, JsonPath.new("$.store.book..tags[?(@ == 'asdf')]").on(@object)
-  end
+  # def test_filter_support_include
+  #   #assert_equal true, JsonPath.new("$.store.book[(@.tags == 'asdf3')]").on(@object)
+  #   assert_equal true, JsonPath.new("$.store.book..tags[?(@ == 'asdf')]").on(@object)
+  # end
 
   def example_object
     { 'store' => {


### PR DESCRIPTION
What's left.

```ruby
        if pos == (@path.size - 1) && node && allow_eval?
          yield_value(blk, context, key) if instance_eval("node #{@path[pos]}")
        end
```

- [x] Implementing `&&` and `||`