### PR TITLE
Fixing checking if operand is a number or not by casting.

### DIFF
--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -46,7 +46,7 @@ class JsonPath
       return false unless el
       return true if operator.nil? && el
 
-      operand = operand.to_f if operand.to_i.to_s == operand || operand.to_f.to_s == operand
+      operand = Float(operand) rescue operand
       el.send(operator.strip, operand)
     end
 

--- a/lib/jsonpath/version.rb
+++ b/lib/jsonpath/version.rb
@@ -1,3 +1,3 @@
 class JsonPath
-  VERSION = '0.8.4'.freeze
+  VERSION = '0.8.5'.freeze
 end

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -76,7 +76,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] < 23 && @['price'] > 9)]").on(@object)
   end
 
-  def test_eval_with_floating_point
+  def test_eval_with_floating_point_and_and
     assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] < 23.0 && @['price'] > 9.0)]").on(@object)
   end
 
@@ -267,6 +267,15 @@ class TestJsonpath < MiniTest::Unit::TestCase
       }
     }
     assert_equal [{ 'type' => 'mps/awesome' }], JsonPath.new("$.data[?(@.type == \"mps/awesome\")]").on(data)
+  end
+
+  def test_floating_point_with_precision_marker
+    data = {
+      'data' => {
+        'type' => 0.00001
+      }
+    }
+    assert_equal [{"type"=>0.00001}], JsonPath.new("$.data[?(@.type == 0.00001)]").on(data)
   end
 
   def example_object


### PR DESCRIPTION
Some benchmarks.

```bash
❯ ruby to_f.vs.cast.rb
Warming up --------------------------------------
                cast   189.307k i/100ms
            cast bad   188.133k i/100ms
                to_f    90.466k i/100ms
            to_f bad    88.079k i/100ms
Calculating -------------------------------------
                cast      5.323M (± 4.8%) i/s -     26.692M in   5.026322s
            cast bad      5.271M (± 5.4%) i/s -     26.339M in   5.012467s
                to_f      1.274M (± 4.3%) i/s -      6.423M in   5.050091s
            to_f bad      1.286M (± 5.7%) i/s -      6.430M in   5.017965s
```