### PR TITLE
Filter with underscore

### DIFF
--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -32,7 +32,7 @@ class JsonPath
           num = scanner.scan(/\d+/)
           return @_current_node.send(sym.to_sym).send(op.to_sym, num.to_i)
         end
-        if t = scanner.scan(/\['[a-zA-Z@&\*\/\$%\^\?]+'\]+/)
+        if t = scanner.scan(/\['[a-zA-Z@&\*\/\$%\^\?_]+'\]+/)
           elements << t.gsub(/\[|\]|'|\s+/, '')
         elsif t = scanner.scan(/(\s+)?[<>=][<>=]?(\s+)?/)
           operator = t

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -329,6 +329,20 @@ class TestJsonpath < MiniTest::Unit::TestCase
    assert_equal(['Place'], JsonPath.new("$..mentions[?(@['$type'] == 'Place')].$type").on(jsonld))
   end
 
+  def test_underscore_in_filter
+    jsonld = {
+      "attributes" => [
+        {
+          "store" => [
+             { "with" => "urn" },
+             { "with_underscore" => "urn:1" }
+          ]
+        }
+      ]
+    }
+    assert_equal(['urn:1'], JsonPath.new("$.attributes..store[?(@['with_underscore'] == 'urn:1')].with_underscore").on(jsonld))
+  end
+
   def test_at_in_value
     jsonld = {
       "mentions" =>


### PR DESCRIPTION
The regular expression used when parsing filter expressions would not match on tokens containing an underscore, e.g. `with_underscore`