### PR TITLE
Regression fixing for issue: #83 #82.

### DIFF
--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -14,7 +14,7 @@ class JsonPath
 
   def initialize(path, opts = nil)
     @opts = opts
-    scanner = StringScanner.new(path)
+    scanner = StringScanner.new(path.strip)
     @path = []
     until scanner.eos?
       if token = scanner.scan(/\$\B|@\B|\*|\.\./)

--- a/lib/jsonpath/enumerable.rb
+++ b/lib/jsonpath/enumerable.rb
@@ -66,14 +66,20 @@ class JsonPath
 
     def handle_question_mark(sub_path, node, pos, &blk)
       case node
-      when Hash, Array
-        (node.is_a?(Hash) ? node.keys : (0..node.size)).each do |e|
-          @_current_node = node[e]
+        when Array
+          node.size.times do |index|
+            @_current_node = node[index]
+            # exps = sub_path[1, sub_path.size - 1]
+            # if @_current_node.send("[#{exps.gsub(/@/, '@_current_node')}]")
+              if process_function_or_literal(sub_path[1, sub_path.size - 1])
+                each(@_current_node, nil, pos + 1, &blk)
+              end
+            end
+        when Hash
           if process_function_or_literal(sub_path[1, sub_path.size - 1])
             each(@_current_node, nil, pos + 1, &blk)
           end
-        end
-      else
+          else
         yield node if process_function_or_literal(sub_path[1, sub_path.size - 1])
       end
     end

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -245,7 +245,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
         'id' => '123'
       }
     }
-    assert_equal [{ 'type' => 'users', 'id' => '123' }], JsonPath.new("$.[?(@.type == 'users')]").on(data)
+    assert_equal [{ 'type' => 'users', 'id' => '123' }], JsonPath.new("$.data[?(@.type == 'users')]").on(data)
     assert_equal [], JsonPath.new("$.[?(@.type == 'admins')]").on(data)
   end
 
@@ -285,7 +285,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
         'type' => 0.00001
       }
     }
-    assert_equal [{"type"=>0.00001}], JsonPath.new("$.[?(@.type == 0.00001)]").on(data)
+    assert_equal [{"type"=>0.00001}], JsonPath.new("$.data[?(@.type == 0.00001)]").on(data)
   end
 
   def test_digits_only_string
@@ -295,7 +295,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
         'id' => '123'
       }
     }
-    assert_equal([{"type"=>"users", "id"=>"123"}], JsonPath.new("$.[?(@.id == '123')]").on(data))
+    assert_equal([{"type"=>"users", "id"=>"123"}], JsonPath.new("$.foo[?(@.id == '123')]").on(data))
   end
 
   def test_digits_only_string_in_array
@@ -381,7 +381,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
         'number' => '(492) 080-3961'
       }
     }
-    assert_equal [{'number'=>'(492) 080-3961'}], JsonPath.new("$.[?(@.number == '(492) 080-3961')]").on(data)
+    assert_equal [{'number'=>'(492) 080-3961'}], JsonPath.new("$.data[?(@.number == '(492) 080-3961')]").on(data)
   end
 
 
@@ -484,7 +484,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
       ]
     }.to_json
 
-    assert_equal ['C09C5GYHF'], JsonPath.on(json, "$..[?(@.name == 'general')].id")
+    assert_equal ['C09C5GYHF'], JsonPath.on(json, "$..channels[?(@.name == 'general')].id")
   end
 
   def test_regression_5
@@ -505,6 +505,44 @@ class TestJsonpath < MiniTest::Unit::TestCase
     }.to_json
 
     assert_equal 'C09C5GYHF', JsonPath.on(json, "$..channels[?(@.is_archived == 'false')].id")[0]
+  end
+
+  def test_changed
+    json =
+    {
+      "snapshot"=> {
+        "objects"=> {
+          "whatever"=> [
+            {
+              "column"=> {
+                "name"=> "ASSOCIATE_FLAG",
+                "nullable"=> true
+              }
+            },
+            {
+              "column"=> {
+                "name"=> "AUTHOR",
+                "nullable"=> false
+              }
+            }
+          ]
+        }
+      }
+    }
+    assert_equal true, JsonPath.on(json, "$..column[?(@.name == 'ASSOCIATE_FLAG')].nullable")[0]
+  end
+
+  def test_another
+    json = {
+      initial: true,
+      not: true
+    }.to_json
+    assert_equal [true], JsonPath.on(json, "$.initial[?(@)]")
+    json = {
+      initial: false,
+      not: true
+    }.to_json
+    assert_equal [], JsonPath.on(json, "$.initial[?(@)]")
   end
 
   def example_object

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -545,6 +545,14 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [], JsonPath.on(json, "$.initial[?(@)]")
   end
 
+  def test_hanging
+    json = { initial: true }.to_json
+    success_path = "$.initial"
+    assert_equal [true], JsonPath.on(json, success_path)
+    broken_path = "$.initial\n"
+    assert_equal [true], JsonPath.on(json, broken_path)
+  end
+
   def example_object
     { 'store' => {
       'book' => [


### PR DESCRIPTION
Sorry for dragging you into this @dblock. 

So, look at this PR. It's a regression fix for the attached issues. Apparently, this logic was correct. I fixed the test which was testing for your regression as well, and a small fix made it work. Apparently to this online parser: http://jsonpath.herokuapp.com/ the top level element needs to be included in order for the match to happen.

There were definitely problems here, but also, it seems that my earlier logic fix to this part: https://github.com/joshbuddy/jsonpath/blob/master/lib/jsonpath/enumerable.rb#L69 was, in fact, correct. The other validator was wrong apparently.

Now all the tests are passing. Please everyone involved check if this is correct.
@NDuggan, @SteveDonie and thank you very much for submitting these issues.