### PR TITLE
End index in array slicing should be exclusive

### DIFF
--- a/lib/jsonpath/enumerable.rb
+++ b/lib/jsonpath/enumerable.rb
@@ -51,10 +51,14 @@ class JsonPath
           if array_args[0] == '*'
             start_idx = 0
             end_idx = node.size - 1
+          elsif sub_path.count(':') == 0
+            start_idx = end_idx = process_function_or_literal(array_args[0], 0)
+            next unless start_idx
+            next if start_idx >= node.size
           else
             start_idx = process_function_or_literal(array_args[0], 0)
             next unless start_idx
-            end_idx = (array_args[1] && process_function_or_literal(array_args[1], -1) || (sub_path.count(':') == 0 ? start_idx : -1))
+            end_idx = array_args[1] && ensure_exclusive_end_index(process_function_or_literal(array_args[1], -1)) || -1
             next unless end_idx
             next if start_idx == end_idx && start_idx >= node.size
           end
@@ -70,6 +74,12 @@ class JsonPath
           end
         end
       end
+    end
+
+    def ensure_exclusive_end_index(value)
+      return value unless value.is_a?(Integer) && value > 0
+
+      value - 1
     end
 
     def handle_question_mark(sub_path, node, pos, &blk)

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -48,11 +48,15 @@ class TestJsonpath < MiniTest::Unit::TestCase
   end
 
   def test_recognize_array_splices
-    assert_equal [@object['store']['book'][0], @object['store']['book'][1]], JsonPath.new('$..book[0:1:1]').on(@object)
+    assert_equal [@object['store']['book'][0]], JsonPath.new('$..book[0:1:1]').on(@object)
     assert_equal [@object['store']['book'][1], @object['store']['book'][3], @object['store']['book'][5]], JsonPath.new('$..book[1::2]').on(@object)
     assert_equal [@object['store']['book'][0], @object['store']['book'][2], @object['store']['book'][4], @object['store']['book'][6]], JsonPath.new('$..book[::2]').on(@object)
     assert_equal [@object['store']['book'][0], @object['store']['book'][2]], JsonPath.new('$..book[:-5:2]').on(@object)
     assert_equal [@object['store']['book'][5], @object['store']['book'][6]], JsonPath.new('$..book[5::]').on(@object)
+  end
+
+  def test_slice_array_with_exclusive_end_correctly
+    assert_equal [@object['store']['book'][0], @object['store']['book'][1]], JsonPath.new('$..book[:2]').on(@object)
   end
 
   def test_recognize_array_comma
@@ -722,7 +726,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
        { 'alfa' => 'beta11' },
        { 'alfa' => 'beta12' }] }
     expected = { 'itemList' => [{ 'alfa' => 'beta1' }] }
-    assert_equal expected, JsonPath.for(a.to_json).delete('$.itemList[1:11:1]').to_hash
+    assert_equal expected, JsonPath.for(a.to_json).delete('$.itemList[1:12:1]').to_hash
   end
 
   def test_delete_more_items_with_stepping


### PR DESCRIPTION
This follows the examples given in https://goessner.net/articles/JsonPath/ where `:2` is equal to `[0,1]`.

Issue: #102