### PR TITLE
Fix bug related to nested groupings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ rvm:
   - 2.3.1
   - ruby-head
   - jruby-head
+
+before_install:
+  - gem install bundler -v '< 2'

--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -47,7 +47,7 @@ class JsonPath
                     elsif t == 'false'
                       false
                     else
-                      operator.strip == '=~' ? t.to_regexp : t.gsub(%r{^'|'$}, '').strip
+                      operator.to_s.strip == '=~' ? t.to_regexp : t.gsub(%r{^'|'$}, '').strip
                     end
         elsif t = scanner.scan(/\/\w+\//)
         elsif t = scanner.scan(/.*/)

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -84,6 +84,11 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] < 23 && @['price'] > 9)]").on(@object)
   end
 
+  def test_nested_grouping
+    path = "$..book[?((@['price'] == 19 && @['author'] == 'Herman Melville') || @['price'] == 23)]"
+    assert_equal [@object['store']['book'][3]], JsonPath.new(path).on(@object)
+  end
+
   def test_eval_with_floating_point_and_and
     assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] < 23.0 && @['price'] > 9.0)]").on(@object)
   end


### PR DESCRIPTION
Prior to this commit if a nested grouping was encountered (ie. `((this && that) || the_other)` the gem would raise the following error:

```
NoMethodError:
  undefined method `strip' for nil:NilClass
```

It appears that in this scenario it's possible that the `operator` variable hasn't yet been set. The proposed fix is simply coercing the variable into a `String` before attempting to call the `#strip` function.