### PR TITLE
Support dot notation and traversing non hashes (ruby objects)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 rvm:
-  - 2.1.6
-  - 2.3.1
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
   - ruby-head
   - jruby-head
 

--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -85,8 +85,7 @@ class JsonPath
           end
         end
 
-      return false if el.nil?
-      return true if operator.nil? && el
+      return (el ? true : false) if el.nil? || operator.nil?
 
       el =
         begin

--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -53,7 +53,7 @@ class JsonPath
       scanner = StringScanner.new(exp)
       elements = []
       until scanner.eos?
-        if t = scanner.scan(%r{\['[a-zA-Z@&\*/\$%\^\?_]+'\]|\.[a-zA-Z_?]+})
+        if t = scanner.scan(%r{\['[a-zA-Z@&\*/\$%\^\?_]+'\]|\.[a-zA-Z0-9_]+[?!]?})
           elements << t.gsub(/[\[\]'\.]|\s+/, '')
         elsif t = scanner.scan(/(\s+)?[<>=!\-+][=~]?(\s+)?/)
           operator = t

--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -53,7 +53,7 @@ class JsonPath
       scanner = StringScanner.new(exp)
       elements = []
       until scanner.eos?
-        if t = scanner.scan(%r{\['[a-zA-Z@&\*/\$%\^\?_]+'\]|\.[a-z?]+})
+        if t = scanner.scan(%r{\['[a-zA-Z@&\*/\$%\^\?_]+'\]|\.[a-zA-Z_?]+})
           elements << t.gsub(/[\[\]'\.]|\s+/, '')
         elsif t = scanner.scan(/(\s+)?[<>=!\-+][=~]?(\s+)?/)
           operator = t

--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -61,7 +61,7 @@ class JsonPath
         end
         if t = scanner.scan(/\['[a-zA-Z@&\*\/\$%\^\?_]+'\]+/)
           elements << t.gsub(/\[|\]|'|\s+/, '')
-        elsif t = scanner.scan(/(\s+)?[<>=][=~]?(\s+)?/)
+        elsif t = scanner.scan(/(\s+)?[<>=!][=~]?(\s+)?/)
           operator = t
         elsif t = scanner.scan(/(\s+)?'?.*'?(\s+)?/)
           # If we encounter a node which does not contain `'` it means

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -70,6 +70,12 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [@object['store']['book'][0], @object['store']['book'][2]], JsonPath.new("$..book[?(@['price'] < 10)]").on(@object)
     assert_equal [@object['store']['book'][0], @object['store']['book'][2]], JsonPath.new("$..book[?(@['price'] == 9)]").on(@object)
     assert_equal [@object['store']['book'][3]], JsonPath.new("$..book[?(@['price'] > 20)]").on(@object)
+    assert_equal [
+      @object['store']['book'][0],
+      @object['store']['book'][4],
+      @object['store']['book'][5],
+      @object['store']['book'][6]
+    ], JsonPath.new("$..book[?(@['category'] != 'fiction')]").on(@object)
   end
 
   def test_or_operator

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -119,6 +119,17 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [@object['store']['bicycle']['2seater']], JsonPath.new('$.store.bicycle.2seater').on(@object)
   end
 
+  def test_recognized_dot_notation_in_filters
+    assert_equal [@object['store']['book'][2], @object['store']['book'][3]], JsonPath.new('$..book[?(@.isbn)]').on(@object)
+  end
+
+  def test_works_on_non_hash
+    klass = Struct.new(:a, :b)
+    object = klass.new('some', 'value')
+
+    assert_equal ['value'], JsonPath.new('$.b').on(object)
+  end
+
   def test_recognize_array_with_evald_index
     assert_equal [@object['store']['book'][2]], JsonPath.new('$..book[(@.length-5)]').on(@object)
   end


### PR DESCRIPTION
This is based on #109, so that commit is in here, too

---

I think the first one is clear: Support traversing hashes by dot notation. Eg:

```rb
JsonPath.new('$.books[?(@.isbn)]').on({
  "books" => [
    { "id": 1, "isbn" => 'abc' },
    { "id": 2 }
  ]
})
#  => [{:id=>1, "isbn"=>"abc"}]
```

I removed some clunky stuff at the beginning of `parse_exp` by simply adding `+` and `-` to the operators.

---

The second one may be debatable: It might be a good addition to parse arbitrary ruby objects. For example you can parse a Rails' ActiveRecord object now. It works by simply sending the key as a method, so for hashes it still does `object[key]` but for other objects it does `object.__send__(key)`.

---

Tests pass all, but since I refactored it a little bit there might be some edge cases that got broken by this. Rubocop ran, too, that's why there's some linting noise.

What do you say in general?