### PR TITLE
WIP: Negate operator

### DIFF
--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -90,6 +90,14 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] < 23 && @['price'] > 9)]").on(@object)
   end
 
+  def test_negate_operator
+    assert_equal [
+      @object['store']['book'][4],
+      @object['store']['book'][5],
+      @object['store']['book'][6]
+    ], JsonPath.new("$..book[?(!(@['price']))]").on(@object)
+  end
+
   def test_nested_grouping
     path = "$..book[?((@['price'] == 19 && @['author'] == 'Herman Melville') || @['price'] == 23)]"
     assert_equal [@object['store']['book'][3]], JsonPath.new(path).on(@object)


### PR DESCRIPTION
Currently the negate operator seems not be be supported. E.g.:

```js
// find only items without price
$..book[?(!(@['price']))]

// find items where author is *not* XXX
$..book[?(!(@['author'] == 'XXX'))]
// can also be written as $..book[?(@['author'] != 'XXX'] without negate operator, but both are valid
```

It means that `!(.*)` should be parsed to negate whatever comes out inside the braces.

I took a look at https://github.com/joshbuddy/jsonpath/blob/master/lib/jsonpath/parser.rb#L25 but the parsing logic seems to start with splitting `&&` and `||` and then taking care of braces. Looks like it should be the other way around now, split expressions by braces first and *then* by `&&` and `||`. In fact this should be done recursively, because inside braces there could be more braces etc., but this is another point.

Maybe I will find time to implement it, currently I don't have it (and can work around it in my app), so it is just here so you know.

cc @Skarlso 

