### PR TITLE
[WIP] Add support for a :use_symbols option (when "json" data is ruby data)

### DIFF
--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -3,6 +3,7 @@
 require 'strscan'
 require 'multi_json'
 require 'jsonpath/proxy'
+require 'jsonpath/dig'
 require 'jsonpath/enumerable'
 require 'jsonpath/version'
 require 'jsonpath/parser'

--- a/lib/jsonpath/dig.rb
+++ b/lib/jsonpath/dig.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class JsonPath
+  module Dig
+
+    # Similar to what Hash#dig or Array#dig
+    def dig(context, *keys)
+      keys.inject(context){|memo,k|
+        dig_one(memo, k)
+      }
+    end
+
+    # Returns a hash mapping each key from keys
+    # to its dig value on context.
+    def dig_as_hash(context, keys)
+      keys.each_with_object({}) do |k, memo|
+        memo[k] = dig_one(context, k)
+      end
+    end
+
+    # Dig the value of k on context.
+    def dig_one(context, k)
+      case context
+      when Hash
+        context.dig(@options[:use_symbols] ? k.to_sym : k)
+      when Array
+        context.dig(k.to_i)
+      else
+        context.__send__(k)
+      end
+    end
+
+    # Yields the block if context has a diggable
+    # value for k
+    def yield_if_diggable(context, k, &blk)
+      if context.is_a?(Hash)
+        context[k] ||= nil if @options[:default_path_leaf_to_null]
+        if @options[:use_symbols]
+          yield if context.key?(k.to_sym)
+        else
+          yield if context.key?(k)
+        end
+      elsif context.respond_to?(k.to_s) && !Object.respond_to?(k.to_s)
+        yield
+      end
+    end
+
+  end
+end

--- a/lib/jsonpath/enumerable.rb
+++ b/lib/jsonpath/enumerable.rb
@@ -45,15 +45,30 @@ class JsonPath
     private
 
     def filter_context(context, keys)
-      keys = keys.map(&:to_sym) if @options[:use_symbols]
       case context
       when Hash
-        # TODO: Change this to `slice(*keys)` when ruby version support is > 2.4
-        context.select { |k| keys.include?(k) }
+        dig_as_hash(context, keys)
       when Array
         context.each_with_object([]) do |c, memo|
-          memo << c.select { |k| keys.include?(k) }
+          memo << dig_as_hash(c, keys)
         end
+      end
+    end
+
+    def dig_as_hash(context, keys)
+      keys.each_with_object({}) do |k, memo|
+        k, v = *dig_one(context, k)
+        memo[k] = v
+      end
+    end
+
+    def dig_one(context, k)
+      k = k.to_sym if @options[:use_symbols]
+      case context
+      when Hash, Array
+        [k, context.dig(k)]
+      else
+        [k, context.__send__(k)]
       end
     end
 

--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -7,9 +7,10 @@ class JsonPath
   class Parser
     REGEX = /\A\/(.+)\/([imxnesu]*)\z|\A%r{(.+)}([imxnesu]*)\z/
 
-    def initialize(node)
+    def initialize(node, options)
       @_current_node = node
       @_expr_map = {}
+      @options = options
     end
 
     # parse will parse an expression in the following way.
@@ -91,7 +92,11 @@ class JsonPath
       el = if elements.empty?
              @_current_node
            elsif @_current_node.is_a?(Hash)
-             @_current_node.dig(*elements)
+             if @options[:use_symbols]
+               @_current_node.dig(*elements.map(&:to_sym))
+             else
+               @_current_node.dig(*elements)
+             end
            else
              elements.inject(@_current_node, &:__send__)
            end

--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -5,6 +5,8 @@ require 'strscan'
 class JsonPath
   # Parser parses and evaluates an expression passed to @_current_node.
   class Parser
+    include Dig
+
     REGEX = /\A\/(.+)\/([imxnesu]*)\z|\A%r{(.+)}([imxnesu]*)\z/
 
     def initialize(node, options)
@@ -92,11 +94,7 @@ class JsonPath
       el = if elements.empty?
              @_current_node
            elsif @_current_node.is_a?(Hash)
-             if @options[:use_symbols]
-               @_current_node.dig(*elements.map(&:to_sym))
-             else
-               @_current_node.dig(*elements)
-             end
+             dig(@_current_node, *elements)
            else
              elements.inject(@_current_node, &:__send__)
            end

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -138,6 +138,22 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal ['other value'], JsonPath.new('$[?(@.a == "next")].b').on([first_object, second_object])
   end
 
+  def test_works_on_non_hash_with_summary
+    object = {
+      "foo" => [{
+        "a" => "some",
+        "b" => "value"
+      }]
+    }
+    assert_equal [{ "b" => "value" }], JsonPath.new("$.foo[*](b)").on(object)
+
+    klass = Struct.new(:a, :b)
+    object = {
+      "foo" => [klass.new("some", "value")]
+    }
+    assert_equal [{ "b" => "value" }], JsonPath.new("$.foo[*](b)").on(object)
+  end
+
   def test_recognize_array_with_evald_index
     assert_equal [@object['store']['book'][2]], JsonPath.new('$..book[(@.length-5)]').on(@object)
   end
@@ -849,7 +865,34 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [], JsonPath.on(json, "$.phoneNumbers[?(@[0].type == 'home')]")
   end
 
-  def test_selecting_multiple_keys
+  def test_selecting_multiple_keys_on_hash
+    json = '
+    {
+      "category": "reference",
+      "author": "Nigel Rees",
+      "title": "Sayings of the Century",
+      "price": 8.95
+    }
+    '.to_json
+    assert_equal [{ 'category' => 'reference', 'author' => 'Nigel Rees' }], JsonPath.on(json, '$.(category,author)')
+  end
+
+  def test_selecting_multiple_keys_on_sub_hash
+    skip("Failing as the semantics of .(x,y) is unclear")
+    json = '
+    {
+      "book": {
+        "category": "reference",
+        "author": "Nigel Rees",
+        "title": "Sayings of the Century",
+        "price": 8.95
+      }
+    }
+    '.to_json
+    assert_equal [{ 'category' => 'reference', 'author' => 'Nigel Rees' }], JsonPath.on(json, '$.book.(category,author)')
+  end
+
+  def test_selecting_multiple_keys_on_array
     json = '
     {
       "store": {
@@ -874,7 +917,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [{ 'category' => 'reference', 'author' => 'Nigel Rees' }, { 'category' => 'fiction', 'author' => 'Evelyn Waugh' }], JsonPath.on(json, '$.store.book[*](category,author)')
   end
 
-  def test_selecting_multiple_keys_with_filter
+  def test_selecting_multiple_keys_on_array_with_filter
     json = '
     {
       "store": {

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -925,6 +925,32 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [{ 'cate gory' => 'reference', 'author' => 'Nigel Rees' }], JsonPath.on(json, "$.store.book[?(@['price'] == 8.95)](   cate gory, author   )")
   end
 
+  def test_use_symbol_opt
+    json = {
+      store: {
+        book: [
+          {
+            category: "reference",
+            author: "Nigel Rees",
+            title: "Sayings of the Century",
+            price: 8.95
+          },
+          {
+            category: "fiction",
+            author: "Evelyn Waugh",
+            title: "Sword of Honour",
+            price: 12.99
+          }
+        ]
+      }
+    }
+    on = ->(path){ JsonPath.on(json, path, use_symbols: true) }
+    assert_equal ['reference', 'fiction'], on.("$.store.book[*].category")
+    assert_equal ['reference', 'fiction'], on.("$..category")
+    assert_equal ['reference'], on.("$.store.book[?(@['price'] == 8.95)].category")
+    assert_equal [{'category' => 'reference'}], on.("$.store.book[?(@['price'] == 8.95)](category)")
+  end
+
   def test_object_method_send
     j = {height: 5, hash: "some_hash"}.to_json
     hs = JsonPath.new "$..send"


### PR DESCRIPTION
Hey @joshbuddy,

I'd like to add JsonPath support to a couple of gems I maintain, e.g. [Bmg](https://github.com/enspirit/bmg), [Predicate](https://github.com/enspirit/predicate) and [Finitio](https://github.com/blambeau/finitio-rb).

Yet there all "data" is actually ruby data, that is with all keys symbolized...

Would you consider merging this PR if I add full support for that, as suggested in the first test?

Thanks, and Merry Christmas.