### PR TITLE
Factorize `dig` logic ; add a few options ; more tests ; fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This is an implementation of http://goessner.net/articles/JsonPath/.
 
 ## What is JsonPath?
 
-JsonPath is a way of addressing elements within a JSON object. Similar to xpath of yore, JsonPath lets you
-traverse a json object and manipulate or access it.
+JsonPath is a way of addressing elements within a JSON object. Similar to xpath
+of yore, JsonPath lets you traverse a json object and manipulate or access it.
 
 ## Usage
 
@@ -15,8 +15,8 @@ There is stand-alone usage through the binary `jsonpath`
 
     jsonpath [expression] (file|string)
 
-    If you omit the second argument, it will read stdin, assuming one valid JSON object
-    per line. Expression must be a valid jsonpath expression.
+    If you omit the second argument, it will read stdin, assuming one valid JSON
+    object per line. Expression must be a valid jsonpath expression.
 
 ### Library
 
@@ -40,8 +40,8 @@ json = <<-HERE_DOC
 HERE_DOC
 ```
 
-Now that we have a JSON object, let's get all the prices present in the object. We create an object for the path
-in the following way.
+Now that we have a JSON object, let's get all the prices present in the object.
+We create an object for the path in the following way.
 
 ```ruby
 path = JsonPath.new('$..price')
@@ -54,14 +54,15 @@ path.on(json)
 # => [19.95, 8.95, 12.99, 8.99, 22.99]
 ```
 
-Or on some other object ...
+Or reuse it later on some other object (thread safe) ...
 
 ```ruby
 path.on('{"books":[{"title":"A Tale of Two Somethings","price":18.88}]}')
 # => [18.88]
 ```
 
-You can also just combine this into one mega-call with the convenient `JsonPath.on` method.
+You can also just combine this into one mega-call with the convenient
+`JsonPath.on` method.
 
 ```ruby
 JsonPath.on(json, '$..author')
@@ -73,29 +74,36 @@ Of course the full JsonPath syntax is supported, such as array slices
 ```ruby
 JsonPath.new('$..book[::2]').on(json)
 # => [
-#      {"price"=>8.95, "category"=>"reference", "author"=>"Nigel Rees", "title"=>"Sayings of the Century"},
-#      {"price"=>8.99, "category"=>"fiction", "author"=>"Herman Melville", "title"=>"Moby Dick", "isbn"=>"0-553-21311-3"}
+#      {"price" => 8.95, "category" => "reference", "title" => "Sayings of the Century", "author" => "Nigel Rees"},
+#      {"price" => 8.99, "category" => "fiction", "isbn" => "0-553-21311-3", "title" => "Moby Dick", "author" => "Herman Melville","color" => "blue"},
 #    ]
 ```
 
-...and evals.
+...and evals, including those with conditional operators
 
 ```ruby
-JsonPath.new('$..price[?(@ < 10)]').on(json)
+JsonPath.new("$..price[?(@ < 10)]").on(json)
 # => [8.95, 8.99]
+
+JsonPath.new("$..book[?(@['price'] == 8.95 || @['price'] == 8.99)].title").on(json)
+# => ["Sayings of the Century", "Moby Dick"]
+
+JsonPath.new("$..book[?(@['price'] == 8.95 && @['price'] == 8.99)].title").on(json)
+# => []
 ```
 
-There is a convenience method, `#first` that gives you the first element for a JSON object and path.
+There is a convenience method, `#first` that gives you the first element for a
+JSON object and path.
 
 ```ruby
-JsonPath.new('$..color').first(object)
+JsonPath.new('$..color').first(json)
 # => "red"
 ```
 
 As well, we can directly create an `Enumerable` at any time using `#[]`. 
 
 ```ruby
-enum = JsonPath.new('$..color')[object]
+enum = JsonPath.new('$..color')[json]
 # => #<JsonPath::Enumerable:...>
 enum.first
 # => "red"
@@ -103,29 +111,50 @@ enum.any?{ |c| c == 'red' }
 # => true
 ```
 
-### More examples
+For more usage examples and variations on paths, please visit the tests. There
+are some more complex ones as well.
 
-For more usage examples and variations on paths, please visit the tests. There are some more complex ones as well.
+### Available options
 
-### Conditional Operators Are Also Supported
+By default, JsonPath does not return null values on unexisting paths.
+This can be changed using the `:default_path_leaf_to_null` option
 
 ```ruby
-  def test_or_operator
-    assert_equal [@object['store']['book'][1], @object['store']['book'][3]], JsonPath.new("$..book[?(@['price'] == 13 || @['price'] == 23)]").on(@object)
-  end
+JsonPath.new('$..book[*].isbn').on(json)
+# => ["0-553-21311-3", "0-395-19395-8"]
 
-  def test_and_operator
-    assert_equal [], JsonPath.new("$..book[?(@['price'] == 13 && @['price'] == 23)]").on(@object)
-  end
+JsonPath.new('$..book[*].isbn', default_path_leaf_to_null: true).on(json)
+# => [nil, nil, "0-553-21311-3", "0-395-19395-8"]
+```
 
-  def test_and_operator_with_more_results
-    assert_equal [@object['store']['book'][1]], JsonPath.new("$..book[?(@['price'] < 23 && @['price'] > 9)]").on(@object)
-  end
+When JsonPath returns a Hash, you can ask to symbolize its keys
+using the `:symbolize_keys` option
+
+```ruby
+JsonPath.new('$..book[0]').on(json)
+# => [{"category" => "reference", ...}]
+
+JsonPath.new('$..book[0]', symbolize_keys: true).on(json)
+# => [{category: "reference", ...}]
+```
+
+If you have ruby hashes with symbolized keys as input, you
+can use `:use_symbols` to make JsonPath work fine on them too:
+
+```ruby
+book = { title: "Sayings of the Century" }
+
+JsonPath.new('$.title').on(book)
+# => []
+
+JsonPath.new('$.title', use_symbols: true).on(book)
+# => ["Sayings of the Century"]
 ```
 
 ### Selecting Values
 
-It's possible to select results once a query has been defined after the query. For example given this JSON data:
+It's possible to select results once a query has been defined after the query. For
+example given this JSON data:
 
 ```bash
 {
@@ -168,15 +197,10 @@ It's possible to select results once a query has been defined after the query. F
 ]
 ```
 
-### Running an individual test
-
-```ruby
-ruby -Ilib:../lib test/test_jsonpath.rb --name test_wildcard_on_intermediary_element_v6
-```
-
 ### Manipulation
 
-If you'd like to do substitution in a json object, you can use `#gsub` or `#gsub!` to modify the object in place.
+If you'd like to do substitution in a json object, you can use `#gsub`
+or `#gsub!` to modify the object in place.
 
 ```ruby
 JsonPath.for('{"candy":"lollipop"}').gsub('$..candy') {|v| "big turks" }.to_hash
@@ -188,7 +212,9 @@ The result will be
 {'candy' => 'big turks'}
 ```
 
-If you'd like to remove all nil keys, you can use `#compact` and `#compact!`. To remove all keys under a certain path, use `#delete` or `#delete!`. You can even chain these methods together as follows:
+If you'd like to remove all nil keys, you can use `#compact` and `#compact!`.
+To remove all keys under a certain path, use `#delete` or `#delete!`. You can
+even chain these methods together as follows:
 
 ```ruby
 json = '{"candy":"lollipop","noncandy":null,"other":"things"}'
@@ -202,4 +228,11 @@ o = JsonPath.for(json).
 
 # Contributions
 
-Please feel free to submit an Issue or a Pull Request any time you feel like you would like to contribute. Thank you!
+Please feel free to submit an Issue or a Pull Request any time you feel like
+you would like to contribute. Thank you!
+
+## Running an individual test
+
+```ruby
+ruby -Ilib:../lib test/test_jsonpath.rb --name test_wildcard_on_intermediary_element_v6
+```

--- a/README.md
+++ b/README.md
@@ -114,7 +114,47 @@ enum.any?{ |c| c == 'red' }
 For more usage examples and variations on paths, please visit the tests. There
 are some more complex ones as well.
 
-### Available options
+### Querying ruby data structures
+
+If you have ruby hashes with symbolized keys as input, you
+can use `:use_symbols` to make JsonPath work fine on them too:
+
+```ruby
+book = { title: "Sayings of the Century" }
+
+JsonPath.new('$.title').on(book)
+# => []
+
+JsonPath.new('$.title', use_symbols: true).on(book)
+# => ["Sayings of the Century"]
+```
+
+JsonPath also recognizes objects responding to `dig` (introduced
+in ruby 2.3), and therefore works out of the box with Struct,
+OpenStruct, and other Hash-like structures:
+
+```ruby
+book_class = Struct.new(:title)
+book = book_class.new("Sayings of the Century")
+
+JsonPath.new('$.title').on(book)
+# => ["Sayings of the Century"]
+```
+
+JsonPath is able to query pure ruby objects and uses `__send__`
+on them. The option is enabled by default in JsonPath 1.x, but
+we encourage to enable it explicitly:
+
+```ruby
+book_class = Class.new{ attr_accessor :title }
+book = book_class.new
+book.title = "Sayings of the Century"
+
+JsonPath.new('$.title', allow_send: true).on(book)
+# => ["Sayings of the Century"]
+```
+
+### Other available options
 
 By default, JsonPath does not return null values on unexisting paths.
 This can be changed using the `:default_path_leaf_to_null` option
@@ -136,19 +176,6 @@ JsonPath.new('$..book[0]').on(json)
 
 JsonPath.new('$..book[0]', symbolize_keys: true).on(json)
 # => [{category: "reference", ...}]
-```
-
-If you have ruby hashes with symbolized keys as input, you
-can use `:use_symbols` to make JsonPath work fine on them too:
-
-```ruby
-book = { title: "Sayings of the Century" }
-
-JsonPath.new('$.title').on(book)
-# => []
-
-JsonPath.new('$.title', use_symbols: true).on(book)
-# => ["Sayings of the Century"]
 ```
 
 ### Selecting Values

--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -13,10 +13,16 @@ require 'jsonpath/parser'
 class JsonPath
   PATH_ALL = '$..*'
 
+  DEFAULT_OPTIONS = {
+    :default_path_leaf_to_null => false,
+    :symbolize_keys => false,
+    :use_symbols => false
+  }
+
   attr_accessor :path
 
   def initialize(path, opts = {})
-    @opts = opts
+    @opts = DEFAULT_OPTIONS.merge(opts)
     scanner = StringScanner.new(path.strip)
     @path = []
     until scanner.eos?

--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -3,6 +3,7 @@
 require 'strscan'
 require 'multi_json'
 require 'jsonpath/proxy'
+require 'jsonpath/dig'
 require 'jsonpath/enumerable'
 require 'jsonpath/version'
 require 'jsonpath/parser'

--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -16,7 +16,8 @@ class JsonPath
   DEFAULT_OPTIONS = {
     :default_path_leaf_to_null => false,
     :symbolize_keys => false,
-    :use_symbols => false
+    :use_symbols => false,
+    :allow_send => true
   }
 
   attr_accessor :path

--- a/lib/jsonpath/dig.rb
+++ b/lib/jsonpath/dig.rb
@@ -26,20 +26,21 @@ class JsonPath
       when Array
         context[k.to_i]
       else
-        context.__send__(k)
+        if context.respond_to?(:dig)
+          context.dig(k)
+        else
+          context.__send__(k)
+        end
       end
     end
 
     # Yields the block if context has a diggable
     # value for k
     def yield_if_diggable(context, k, &blk)
-      if context.is_a?(Hash)
-        context[k] ||= nil if @options[:default_path_leaf_to_null]
-        if @options[:use_symbols]
-          yield if context.key?(k.to_sym)
-        else
-          yield if context.key?(k)
-        end
+      return if context.is_a?(Array)
+      if context.respond_to?(:dig)
+        digged = dig_one(context, k)
+        yield if !digged.nil? || @options[:default_path_leaf_to_null]
       elsif context.respond_to?(k.to_s) && !Object.respond_to?(k.to_s)
         yield
       end

--- a/lib/jsonpath/dig.rb
+++ b/lib/jsonpath/dig.rb
@@ -28,7 +28,7 @@ class JsonPath
       else
         if context.respond_to?(:dig)
           context.dig(k)
-        else
+        elsif @options[:allow_send]
           context.__send__(k)
         end
       end
@@ -47,7 +47,7 @@ class JsonPath
         if context.respond_to?(:dig)
           digged = dig_one(context, k)
           yield if !digged.nil? || @options[:default_path_leaf_to_null]
-        elsif context.respond_to?(k.to_s) && !Object.respond_to?(k.to_s)
+        elsif @options[:allow_send] && context.respond_to?(k.to_s) && !Object.respond_to?(k.to_s)
           yield
         end
       end

--- a/lib/jsonpath/dig.rb
+++ b/lib/jsonpath/dig.rb
@@ -22,7 +22,7 @@ class JsonPath
     def dig_one(context, k)
       case context
       when Hash
-        context[k]
+        context[@options[:use_symbols] ? k.to_sym : k]
       when Array
         context[k.to_i]
       else
@@ -35,7 +35,11 @@ class JsonPath
     def yield_if_diggable(context, k, &blk)
       if context.is_a?(Hash)
         context[k] ||= nil if @options[:default_path_leaf_to_null]
-        yield if context.key?(k)
+        if @options[:use_symbols]
+          yield if context.key?(k.to_sym)
+        else
+          yield if context.key?(k)
+        end
       elsif context.respond_to?(k.to_s) && !Object.respond_to?(k.to_s)
         yield
       end

--- a/lib/jsonpath/dig.rb
+++ b/lib/jsonpath/dig.rb
@@ -37,12 +37,19 @@ class JsonPath
     # Yields the block if context has a diggable
     # value for k
     def yield_if_diggable(context, k, &blk)
-      return if context.is_a?(Array)
-      if context.respond_to?(:dig)
-        digged = dig_one(context, k)
-        yield if !digged.nil? || @options[:default_path_leaf_to_null]
-      elsif context.respond_to?(k.to_s) && !Object.respond_to?(k.to_s)
-        yield
+      case context
+      when Array
+        nil
+      when Hash
+        k = @options[:use_symbols] ? k.to_sym : k
+        return yield if context.key?(k) || @options[:default_path_leaf_to_null]
+      else
+        if context.respond_to?(:dig)
+          digged = dig_one(context, k)
+          yield if !digged.nil? || @options[:default_path_leaf_to_null]
+        elsif context.respond_to?(k.to_s) && !Object.respond_to?(k.to_s)
+          yield
+        end
       end
     end
 

--- a/lib/jsonpath/dig.rb
+++ b/lib/jsonpath/dig.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class JsonPath
+  module Dig
+
+    # Similar to what Hash#dig or Array#dig
+    def dig(context, *keys)
+      keys.inject(context){|memo,k|
+        dig_one(memo, k)
+      }
+    end
+
+    # Returns a hash mapping each key from keys
+    # to its dig value on context.
+    def dig_as_hash(context, keys)
+      keys.each_with_object({}) do |k, memo|
+        memo[k] = dig_one(context, k)
+      end
+    end
+
+    # Dig the value of k on context.
+    def dig_one(context, k)
+      case context
+      when Hash
+        context[k]
+      when Array
+        context[k.to_i]
+      else
+        context.__send__(k)
+      end
+    end
+
+    # Yields the block if context has a diggable
+    # value for k
+    def yield_if_diggable(context, k, &blk)
+      if context.is_a?(Hash)
+        context[k] ||= nil if @options[:default_path_leaf_to_null]
+        yield if context.key?(k)
+      elsif context.respond_to?(k.to_s) && !Object.respond_to?(k.to_s)
+        yield
+      end
+    end
+
+  end
+end

--- a/lib/jsonpath/enumerable.rb
+++ b/lib/jsonpath/enumerable.rb
@@ -63,6 +63,7 @@ class JsonPath
           handle_question_mark(sub_path, node, pos, &blk)
         else
           next if node.is_a?(Array) && node.empty?
+          next if node.nil? # when default_path_leaf_to_null is true
 
           array_args = sub_path.split(':')
           if array_args[0] == '*'

--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -5,11 +5,14 @@ require 'strscan'
 class JsonPath
   # Parser parses and evaluates an expression passed to @_current_node.
   class Parser
+    include Dig
+
     REGEX = /\A\/(.+)\/([imxnesu]*)\z|\A%r{(.+)}([imxnesu]*)\z/
 
-    def initialize(node)
+    def initialize(node, options)
       @_current_node = node
       @_expr_map = {}
+      @options = options
     end
 
     # parse will parse an expression in the following way.
@@ -91,7 +94,7 @@ class JsonPath
       el = if elements.empty?
              @_current_node
            elsif @_current_node.is_a?(Hash)
-             @_current_node.dig(*elements)
+             dig(@_current_node, *elements)
            else
              elements.inject(@_current_node, &:__send__)
            end

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -130,6 +130,26 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal ['value'], JsonPath.new('$.b').on(object)
   end
 
+  def test_works_on_diggable
+    klass = Class.new{
+      attr_reader :h
+      def initialize(h)
+        @h = h
+      end
+      def dig(*keys)
+        @h.dig(*keys)
+      end
+    }
+
+    object = klass.new('a' => 'some', 'b' => 'value')
+    assert_equal ['value'], JsonPath.new('$.b').on(object)
+
+    object = {
+      "foo" => klass.new('a' => 'some', 'b' => 'value')
+    }
+    assert_equal ['value'], JsonPath.new('$.foo.b').on(object)
+  end
+
   def test_works_on_non_hash_with_filters
     klass = Struct.new(:a, :b)
     first_object = klass.new('some', 'value')

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -970,6 +970,32 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [{ 'cate gory' => 'reference', 'author' => 'Nigel Rees' }], JsonPath.on(json, "$.store.book[?(@['price'] == 8.95)](   cate gory, author   )")
   end
 
+  def test_use_symbol_opt
+    json = {
+      store: {
+        book: [
+          {
+            category: "reference",
+            author: "Nigel Rees",
+            title: "Sayings of the Century",
+            price: 8.95
+          },
+          {
+            category: "fiction",
+            author: "Evelyn Waugh",
+            title: "Sword of Honour",
+            price: 12.99
+          }
+        ]
+      }
+    }
+    on = ->(path){ JsonPath.on(json, path, use_symbols: true) }
+    assert_equal ['reference', 'fiction'], on.("$.store.book[*].category")
+    assert_equal ['reference', 'fiction'], on.("$..category")
+    assert_equal ['reference'], on.("$.store.book[?(@['price'] == 8.95)].category")
+    assert_equal [{'category' => 'reference'}], on.("$.store.book[?(@['price'] == 8.95)](category)")
+  end
+
   def test_object_method_send
     j = {height: 5, hash: "some_hash"}.to_json
     hs = JsonPath.new "$..send"

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -149,7 +149,6 @@ class TestJsonpath < MiniTest::Unit::TestCase
   end
 
   def test_works_on_non_hash_with_summary
-    skip("This does not work currently")
     klass = Struct.new(:a, :b)
     object = {
       "foo" => [klass.new("some", "value")]

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -130,6 +130,30 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal ['value'], JsonPath.new('$.b').on(object)
   end
 
+  def test_works_on_object
+    klass = Class.new{
+      attr_reader :b
+      def initialize(b)
+        @b = b
+      end
+    }
+    object = klass.new("value")
+
+    assert_equal ["value"], JsonPath.new('$.b').on(object)
+  end
+
+  def test_works_on_object_can_be_disabled
+    klass = Class.new{
+      attr_reader :b
+      def initialize(b)
+        @b = b
+      end
+    }
+    object = klass.new("value")
+
+    assert_equal [], JsonPath.new('$.b', allow_send: false).on(object)
+  end
+
   def test_works_on_diggable
     klass = Class.new{
       attr_reader :h

--- a/test/test_readme.rb
+++ b/test/test_readme.rb
@@ -45,16 +45,27 @@ class TestJsonpathReadme < MiniTest::Unit::TestCase
     assert enum.any?{ |c| c == 'red' }
   end
 
+  def test_ruby_structures_section
+    book = { title: "Sayings of the Century" }
+    assert_equal [], JsonPath.new('$.title').on(book)
+    assert_equal ["Sayings of the Century"], JsonPath.new('$.title', use_symbols: true).on(book)
+
+    book_class = Struct.new(:title)
+    book = book_class.new("Sayings of the Century")
+    assert_equal ["Sayings of the Century"], JsonPath.new('$.title').on(book)
+
+    book_class = Class.new{ attr_accessor :title }
+    book = book_class.new
+    book.title = "Sayings of the Century"
+    assert_equal ["Sayings of the Century"], JsonPath.new('$.title', allow_send: true).on(book)
+  end
+
   def test_options_section
     assert_equal ["0-553-21311-3", "0-395-19395-8"], JsonPath.new('$..book[*].isbn').on(json)
     assert_equal [nil, nil, "0-553-21311-3", "0-395-19395-8"], JsonPath.new('$..book[*].isbn', default_path_leaf_to_null: true).on(json)
 
     assert_equal ["price", "category", "title", "author"], JsonPath.new('$..book[0]').on(json).map(&:keys).flatten.uniq
     assert_equal [:price, :category, :title, :author], JsonPath.new('$..book[0]').on(json, symbolize_keys: true).map(&:keys).flatten.uniq
-
-    book = { title: "Sayings of the Century" }
-    assert_equal [], JsonPath.new('$.title').on(book)
-    assert_equal ["Sayings of the Century"], JsonPath.new('$.title', use_symbols: true).on(book)
   end
 
   def selecting_value_section

--- a/test/test_readme.rb
+++ b/test/test_readme.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'phocus'
+require 'jsonpath'
+require 'json'
+
+class TestJsonpathReadme < MiniTest::Unit::TestCase
+
+  def setup
+    @json = <<-HERE_DOC
+    {"store":
+      {"bicycle":
+        {"price":19.95, "color":"red"},
+        "book":[
+          {"price":8.95, "category":"reference", "title":"Sayings of the Century", "author":"Nigel Rees"},
+          {"price":12.99, "category":"fiction", "title":"Sword of Honour", "author":"Evelyn Waugh"},
+          {"price":8.99, "category":"fiction", "isbn":"0-553-21311-3", "title":"Moby Dick", "author":"Herman Melville","color":"blue"},
+          {"price":22.99, "category":"fiction", "isbn":"0-395-19395-8", "title":"The Lord of the Rings", "author":"Tolkien"}
+        ]
+      }
+    }
+    HERE_DOC
+  end
+  attr_reader :json
+
+  def test_library_section
+    path = JsonPath.new('$..price')
+    assert_equal [19.95, 8.95, 12.99, 8.99, 22.99], path.on(json)
+    assert_equal [18.88], path.on('{"books":[{"title":"A Tale of Two Somethings","price":18.88}]}')
+    assert_equal ["Nigel Rees", "Evelyn Waugh", "Herman Melville", "Tolkien"], JsonPath.on(json, '$..author')
+    assert_equal [
+      {"price" => 8.95, "category" => "reference", "title" => "Sayings of the Century", "author" => "Nigel Rees"},
+      {"price" => 8.99, "category" => "fiction", "isbn" => "0-553-21311-3", "title" => "Moby Dick", "author" => "Herman Melville","color" => "blue"},
+    ], JsonPath.new('$..book[::2]').on(json)
+    assert_equal [8.95, 8.99], JsonPath.new("$..price[?(@ < 10)]").on(json)
+    assert_equal ["Sayings of the Century", "Moby Dick"], JsonPath.new("$..book[?(@['price'] == 8.95 || @['price'] == 8.99)].title").on(json)
+    assert_equal [], JsonPath.new("$..book[?(@['price'] == 8.95 && @['price'] == 8.99)].title").on(json)
+    assert_equal "red", JsonPath.new('$..color').first(json)
+  end
+
+  def test_library_section_enumerable
+    enum = JsonPath.new('$..color')[json]
+    assert_equal "red", enum.first
+    assert enum.any?{ |c| c == 'red' }
+  end
+
+  def test_options_section
+    assert_equal ["0-553-21311-3", "0-395-19395-8"], JsonPath.new('$..book[*].isbn').on(json)
+    assert_equal [nil, nil, "0-553-21311-3", "0-395-19395-8"], JsonPath.new('$..book[*].isbn', default_path_leaf_to_null: true).on(json)
+
+    assert_equal ["price", "category", "title", "author"], JsonPath.new('$..book[0]').on(json).map(&:keys).flatten.uniq
+    assert_equal [:price, :category, :title, :author], JsonPath.new('$..book[0]').on(json, symbolize_keys: true).map(&:keys).flatten.uniq
+
+    book = { title: "Sayings of the Century" }
+    assert_equal [], JsonPath.new('$.title').on(book)
+    assert_equal ["Sayings of the Century"], JsonPath.new('$.title', use_symbols: true).on(book)
+  end
+
+  def selecting_value_section
+    json = <<-HERE_DOC
+    {
+        "store": {
+            "book": [
+                {
+                    "category": "reference",
+                    "author": "Nigel Rees",
+                    "title": "Sayings of the Century",
+                    "price": 8.95
+                },
+                {
+                    "category": "fiction",
+                    "author": "Evelyn Waugh",
+                    "title": "Sword of Honour",
+                    "price": 12.99
+                }
+            ]
+    }
+    HERE_DOC
+    got = JsonPath.on(json, "$.store.book[*](category,author)")
+    expected = [
+       {
+          "category" => "reference",
+          "author" => "Nigel Rees"
+       },
+       {
+          "category" => "fiction",
+          "author" => "Evelyn Waugh"
+       }
+    ]
+    assert_equal expected, got
+  end
+
+  def test_manipulation_section
+    assert_equal({"candy" => "big turks"}, JsonPath.for('{"candy":"lollipop"}').gsub('$..candy') {|v| "big turks" }.to_hash)
+
+    json = '{"candy":"lollipop","noncandy":null,"other":"things"}'
+    o = JsonPath.for(json).
+      gsub('$..candy') {|v| "big turks" }.
+      compact.
+      delete('$..other').
+      to_hash
+    assert_equal({"candy" => "big turks"}, o)
+  end
+
+end


### PR DESCRIPTION
@Skarlso I restarted my branch with another strategy, but with same goal (support for symbolized keys).

Maybe you need to look at commits in order, but basically:
1. I added some additional tests
2. I refactored some `dig` logic without breaking anything
3. Then and only then I added support for more `dig` scenario and the symbols option
4. I also gave some love to the README (available options) and added unit tests for it

WDYT?