### PR TITLE
duck-type values responding to #to_hash or #to_ary

### DIFF
--- a/lib/jsonpath/dig.rb
+++ b/lib/jsonpath/dig.rb
@@ -20,11 +20,10 @@ class JsonPath
 
     # Dig the value of k on context.
     def dig_one(context, k)
-      case context
-      when Hash
-        context[@options[:use_symbols] ? k.to_sym : k]
-      when Array
-        context[k.to_i]
+      if context.respond_to?(:to_hash)
+        context.to_hash[@options[:use_symbols] ? k.to_sym : k]
+      elsif context.respond_to?(:to_ary)
+        context.to_ary[k.to_i]
       else
         if context.respond_to?(:dig)
           context.dig(k)
@@ -37,12 +36,11 @@ class JsonPath
     # Yields the block if context has a diggable
     # value for k
     def yield_if_diggable(context, k, &blk)
-      case context
-      when Array
+      if context.respond_to?(:to_ary)
         nil
-      when Hash
+      elsif context.respond_to?(:to_hash)
         k = @options[:use_symbols] ? k.to_sym : k
-        return yield if context.key?(k) || @options[:default_path_leaf_to_null]
+        return yield if context.to_hash.key?(k) || @options[:default_path_leaf_to_null]
       else
         if context.respond_to?(:dig)
           digged = dig_one(context, k)

--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -58,7 +58,7 @@ class JsonPath
         next if i.empty?
 
         index = Integer(i[0])
-        raise ArgumentError, 'Node does not appear to be an array.' unless @_current_node.is_a?(Array)
+        raise ArgumentError, 'Node does not appear to be an array.' unless @_current_node.respond_to?(:to_ary)
         raise ArgumentError, "Index out of bounds for nested array. Index: #{index}" if @_current_node.size < index
 
         @_current_node = @_current_node[index]
@@ -93,7 +93,7 @@ class JsonPath
 
       el = if elements.empty?
              @_current_node
-           elsif @_current_node.is_a?(Hash)
+           elsif @_current_node.respond_to?(:to_hash)
              dig(@_current_node, *elements)
            else
              elements.inject(@_current_node, &:__send__)

--- a/lib/jsonpath/proxy.rb
+++ b/lib/jsonpath/proxy.rb
@@ -52,7 +52,7 @@ class JsonPath
 
     def _remove(obj)
       obj.each do |o|
-        if o.is_a?(Hash) || o.is_a?(Array)
+        if o.respond_to?(:to_hash) || o.respond_to?(:to_ary)
           _remove(o)
           o.delete({})
         end


### PR DESCRIPTION
I work with JSON data wrapped in classes which behave like Hash and Array, which respond to #to_hash / #to_ary to support implicit conversion (as described in https://docs.ruby-lang.org/en/master/doc/implicit_conversion_rdoc.html )

this PR lets jsonpath be used with these implicitly convertible objects. my goal is to search the wrapped document and get wrapped children out as the result(s).

it is in draft because I have updated no tests, and may be incomplete in other ways. if an active maintainer thinks it is a good idea to merge, I will bring it to completion. 
