### PR TITLE
Add Option to configure max_nesting

### DIFF
--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -93,7 +93,7 @@ class JsonPath
   end
 
   def enum_on(obj_or_str, mode = nil)
-    JsonPath::Enumerable.new(self, self.class.process_object(obj_or_str), mode,
+    JsonPath::Enumerable.new(self, self.class.process_object(obj_or_str, @opts), mode,
                              @opts)
   end
   alias [] enum_on

--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -17,7 +17,8 @@ class JsonPath
     :default_path_leaf_to_null => false,
     :symbolize_keys => false,
     :use_symbols => false,
-    :allow_send => true
+    :allow_send => true,
+    :max_nesting => 100
   }
 
   attr_accessor :path
@@ -107,8 +108,8 @@ class JsonPath
 
   private
 
-  def self.process_object(obj_or_str)
-    obj_or_str.is_a?(String) ? MultiJson.decode(obj_or_str) : obj_or_str
+  def self.process_object(obj_or_str, opts = {})
+    obj_or_str.is_a?(String) ? MultiJson.decode(obj_or_str, max_nesting: opts[:max_nesting]) : obj_or_str
   end
 
   def deep_clone

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -1098,6 +1098,32 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [12, nil, nil], JsonPath.new('$.bars[*].foo', default_path_leaf_to_null: true).on(data)
   end
 
+  def test_raise_max_nesting_error
+    json = {
+      a: {
+        b: {
+          c: {
+          }
+        }
+      }
+    }.to_json
+
+    assert_raises(MultiJson::ParseError) { JsonPath.new('$.a', max_nesting: 1).on(json) }
+  end
+
+  def test_with_max_nesting_false
+    json = {
+      a: {
+        b: {
+          c: {
+          }
+        }
+      }
+    }.to_json
+
+    assert_equal [{}], JsonPath.new('$.a.b.c', max_nesting: false).on(json)
+  end
+
   def example_object
     { 'store' => {
       'book' => [


### PR DESCRIPTION
JSON default allows 100 level deep parsing. If you want to go beyond 100 level we need to configure max_nesting.

<img width="1082" alt="Screen Shot 2022-03-08 at 1 10 19 PM" src="https://user-images.githubusercontent.com/73137373/157299505-97eb6395-73d7-4dc8-b413-928162988582.png">

Steps for Reproduce: 

Try to Prase 101 level deep hash `JsonPath.new('$.a').on(101_level_deep_hash)` will get above error.
