### PR TITLE
bug #147: stop at character '!' when scanning key name, to avoid consuming first char of operator '!='

### DIFF
--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -68,7 +68,7 @@ class JsonPath
       scanner = StringScanner.new(exp)
       elements = []
       until scanner.eos?
-        if (t = scanner.scan(/\['[a-zA-Z@&*\/$%^?_]+'\]|\.[a-zA-Z0-9_]+[?!]?/))
+        if (t = scanner.scan(/\['[a-zA-Z@&*\/$%^?_]+'\]|\.[a-zA-Z0-9_]+[?]?/))
           elements << t.gsub(/[\[\]'.]|\s+/, '')
         elsif (t = scanner.scan(/(\s+)?[<>=!\-+][=~]?(\s+)?/))
           operator = t


### PR DESCRIPTION
fixes bug #147 