### PR TITLE
Remove rubocop for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@
 
 source 'http://rubygems.org'
 gemspec
-gem 'rubocop', require: true, group: :test
+# gem 'rubocop', require: true, group: :test
 gem 'simplecov', require: false, group: :test


### PR DESCRIPTION
It is apparently breaking on a new release of regexp_parser (2.3.1) in the github action bundle step.