### PR TITLE
Fix for negating a filter script

### DIFF
--- a/lib/jsonpath/parser.rb
+++ b/lib/jsonpath/parser.rb
@@ -99,6 +99,7 @@ class JsonPath
              elements.inject(@_current_node, &:__send__)
            end
 
+      return !el if operator&.strip == '!' && operand.nil?
       return (el ? true : false) if el.nil? || operator.nil?
 
       el = Float(el) rescue el

--- a/lib/jsonpath/version.rb
+++ b/lib/jsonpath/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class JsonPath
-  VERSION = '1.1.2'
+  VERSION = '1.1.3'
 end

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -67,6 +67,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
 
   def test_recognize_filters
     assert_equal [@object['store']['book'][2], @object['store']['book'][3]], JsonPath.new("$..book[?(@['isbn'])]").on(@object)
+    assert_equal [@object['store']['book'][0], @object['store']['book'][1], @object['store']['book'][4], @object['store']['book'][5], @object['store']['book'][6]], JsonPath.new("$..book[?(!@['isbn'])]").on(@object)
     assert_equal [@object['store']['book'][0], @object['store']['book'][2]], JsonPath.new("$..book[?(@['price'] < 10)]").on(@object)
     assert_equal [@object['store']['book'][0], @object['store']['book'][2]], JsonPath.new("$..book[?(@['price'] == 9)]").on(@object)
     assert_equal [@object['store']['book'][3]], JsonPath.new("$..book[?(@['price'] > 20)]").on(@object)
@@ -157,6 +158,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
 
   def test_recognized_dot_notation_in_filters
     assert_equal [@object['store']['book'][2], @object['store']['book'][3]], JsonPath.new('$..book[?(@.isbn)]').on(@object)
+    assert_equal [@object['store']['book'][0], @object['store']['book'][1], @object['store']['book'][4], @object['store']['book'][5], @object['store']['book'][6]], JsonPath.new("$..book[?(!@.isbn)]").on(@object)
   end
 
   def test_works_on_non_hash


### PR DESCRIPTION
Fixes https://github.com/joshbuddy/jsonpath/issues/151

Added a check for the situation where `!` is the operator, and there is no operand. This allows us to use a JSONPath like `$[?(!@['pull_request'])]` or `$[?(!@.pull_request)]` where we want to receive the items from an array that **don't** have a `pull_request` key.

Open to feedback on this. I know it's not an overly generic fix, but this seems like a pretty specific edge case, so I figured a specific check would be warranted.