### PR TITLE
fix: Parser hangs on mid-string line feed character

### DIFF
--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -44,7 +44,7 @@ class JsonPath
         nil
       elsif (token = scanner.scan(/[><=] \d+/))
         @path.last << token
-      elsif (token = scanner.scan(/./))
+      elsif (token = scanner.scan(/./m))
         begin
           @path.last << token
         rescue RuntimeError

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -1178,6 +1178,10 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_raises(MultiJson::ParseError) { JsonPath.new('$.a', max_nesting: 1).on(json) }
   end
 
+  def test_linefeed_in_path_error
+    assert_raises(ArgumentError) { JsonPath.new("$.store\n.book") }
+  end
+
   def test_with_max_nesting_false
     json = {
       a: {


### PR DESCRIPTION
I noticed this when splitting long paths over multiple lines with a heredoc:
```ruby
path = <<~PATH
  $.requestResponse.responseInfo.allClientInfo.abcdeSummary.
    stats[?(@.type == total)].value
PATH
```
I'm fine with having a local wrapper in my app to remove those characters, but the library should probably raise an error instead of hang.