### PR TITLE
Jsonpath with keyname $ not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ o = JsonPath.for(json).
 
 ### Fetch all paths
 
-To fetch all possible paths in given json, you can use `fetch_all_paths` method.
+To fetch all possible paths in given json, you can use `fetch_all_path`` method.
 
 data:
 

--- a/lib/jsonpath/enumerable.rb
+++ b/lib/jsonpath/enumerable.rb
@@ -21,7 +21,11 @@ class JsonPath
       when '*', '..', '@'
         each(context, key, pos + 1, &blk)
       when '$'
-        each(context, key, pos + 1, &blk) if node == @object
+        if node == @object
+          each(context, key, pos + 1, &blk)
+        else
+          handle_wildecard(node, "['#{expr}']", context, key, pos, &blk)
+        end
       when /^\[(.*)\]$/
         handle_wildecard(node, expr, context, key, pos, &blk)
       when /\(.*\)/

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -1260,4 +1260,11 @@ class TestJsonpath < MiniTest::Unit::TestCase
     }
     assert_equal ["$", "$.foo", "$.bar", "$.bar.baz", "$.bars", "$.bars[0].foo", "$.bars[0]", "$.bars[1].foo", "$.bars[1]", "$.bars[2]"], JsonPath.fetch_all_path(data)
   end
+
+
+  def test_extractore_with_dollar_key
+    json = {"test" => {"$" =>"success", "a" => "123"}}
+    assert_equal ["success"],  JsonPath.on(json, "$.test.$")
+    assert_equal ["123"],  JsonPath.on(json, "$.test.a")
+  end
 end


### PR DESCRIPTION
https://github.com/joshbuddy/jsonpath/issues/153
When "$" is used as a key in an object, the Enumerator treats it as a root instead of a key inside an object, fixed that by calling `handle_wildecard `  if the given node is not equal to the actual object then it's not a root
Updated readme with the correct function name