### PR TITLE
Fix issue #141: nesting of 101 too deep

### DIFF
--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -12,20 +12,21 @@ require 'jsonpath/parser'
 # into a token array.
 class JsonPath
   PATH_ALL = '$..*'
+  MAX_NESTING_ALLOWED = 100
 
   DEFAULT_OPTIONS = {
     :default_path_leaf_to_null => false,
     :symbolize_keys => false,
     :use_symbols => false,
     :allow_send => true,
-    :max_nesting => 100
+    :max_nesting => MAX_NESTING_ALLOWED
   }
 
   attr_accessor :path
 
   def initialize(path, opts = {})
     @opts = DEFAULT_OPTIONS.merge(opts)
-    @opts[:max_nesting] = false if @opts[:max_nesting] > 100
+    @opts[:max_nesting] = false if @opts[:max_nesting] > MAX_NESTING_ALLOWED
     scanner = StringScanner.new(path.strip)
     @path = []
     until scanner.eos?

--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -25,6 +25,7 @@ class JsonPath
 
   def initialize(path, opts = {})
     @opts = DEFAULT_OPTIONS.merge(opts)
+    @opts[:max_nesting] = false if @opts[:max_nesting] > 100
     scanner = StringScanner.new(path.strip)
     @path = []
     until scanner.eos?

--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -26,7 +26,7 @@ class JsonPath
 
   def initialize(path, opts = {})
     @opts = DEFAULT_OPTIONS.merge(opts)
-    @opts[:max_nesting] = false if @opts[:max_nesting] > MAX_NESTING_ALLOWED
+    set_max_nesting
     scanner = StringScanner.new(path.strip)
     @path = []
     until scanner.eos?
@@ -147,5 +147,10 @@ class JsonPath
 
   def deep_clone
     Marshal.load Marshal.dump(self)
+  end
+
+  def set_max_nesting
+    return unless @opts[:max_nesting].is_a?(Integer) && @opts[:max_nesting] > MAX_NESTING_ALLOWED
+    @opts[:max_nesting] = false
   end
 end

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -1210,6 +1210,16 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal false, json_obj.instance_variable_get(:@opts)[:max_nesting]
   end
 
+  def test_initialize_without_max_nesting_exceeding_limit
+    json_obj = JsonPath.new('$.a.b.c', max_nesting: 90)
+    assert_equal 90, json_obj.instance_variable_get(:@opts)[:max_nesting]
+  end
+
+  def test_initialize_with_max_nesting_false_limit
+    json_obj = JsonPath.new('$.a.b.c', max_nesting: false)
+    assert_equal false, json_obj.instance_variable_get(:@opts)[:max_nesting]
+  end
+
   def example_object
     { 'store' => {
       'book' => [

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -1195,6 +1195,21 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [{}], JsonPath.new('$.a.b.c', max_nesting: false).on(json)
   end
 
+  def test_initialize_with_max_nesting_exceeding_limit
+    json = {
+      a: {
+        b: {
+          c: {
+          }
+        }
+      }
+    }.to_json
+
+    json_obj = JsonPath.new('$.a.b.c', max_nesting: 105)
+    assert_equal [{}], json_obj.on(json)
+    assert_equal false, json_obj.instance_variable_get(:@opts)[:max_nesting]
+  end
+
   def example_object
     { 'store' => {
       'book' => [


### PR DESCRIPTION
Fix for https://github.com/joshbuddy/jsonpath/issues/141
setting max_nesting to false when max_nesting is greater than 100