### PR TITLE
Update member name regexp to support UTF8 alphanumeric characters

### DIFF
--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -30,7 +30,7 @@ class JsonPath
     until scanner.eos?
       if (token = scanner.scan(/\$\B|@\B|\*|\.\./))
         @path << token
-      elsif (token = scanner.scan(/[$@\p{Alnum}:{}_-]+/))
+      elsif (token = scanner.scan(/[$@\p{Alnum}:{}_ -]+/))
         @path << "['#{token}']"
       elsif (token = scanner.scan(/'(.*?)'/))
         @path << "[#{token}]"

--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -30,7 +30,7 @@ class JsonPath
     until scanner.eos?
       if (token = scanner.scan(/\$\B|@\B|\*|\.\./))
         @path << token
-      elsif (token = scanner.scan(/[$@a-zA-Z0-9:{}_-]+/))
+      elsif (token = scanner.scan(/[$@\p{Alnum}:{}_-]+/))
         @path << "['#{token}']"
       elsif (token = scanner.scan(/'(.*?)'/))
         @path << "[#{token}]"
@@ -85,7 +85,7 @@ class JsonPath
     end
     a
   end
-  
+
   def self.fetch_all_path(obj)
     all_paths = ['$']
     find_path(obj, '$', all_paths, obj.class == Array)

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -245,7 +245,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
   end
 
   def test_counting
-    assert_equal 57, JsonPath.new('$..*').on(@object).to_a.size
+    assert_equal 58, JsonPath.new('$..*').on(@object).to_a.size
   end
 
   def test_space_in_path
@@ -473,6 +473,11 @@ class TestJsonpath < MiniTest::Unit::TestCase
   def test_support_underscore_in_member_names
     assert_equal [@object['store']['_links']],
                  JsonPath.new('$.store._links').on(@object)
+  end
+
+  def test_support_for_umlauts_in_member_names
+    assert_equal [@object['store']['Übermorgen']],
+                 JsonPath.new('$.store.Übermorgen').on(@object)
   end
 
   def test_dig_return_string
@@ -1246,10 +1251,11 @@ class TestJsonpath < MiniTest::Unit::TestCase
       },
       '@id' => 'http://example.org/store/42',
       '$meta-data' => 'whatevs',
+      'Übermorgen' => 'The day after tomorrow',
       '_links' => { 'self' => {} }
     } }
   end
-  
+
   def test_fetch_all_path
     data = {
       "foo" => nil,

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -245,7 +245,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
   end
 
   def test_counting
-    assert_equal 58, JsonPath.new('$..*').on(@object).to_a.size
+    assert_equal 59, JsonPath.new('$..*').on(@object).to_a.size
   end
 
   def test_space_in_path
@@ -478,6 +478,11 @@ class TestJsonpath < MiniTest::Unit::TestCase
   def test_support_for_umlauts_in_member_names
     assert_equal [@object['store']['Übermorgen']],
                  JsonPath.new('$.store.Übermorgen').on(@object)
+  end
+
+  def test_support_for_spaces_in_member_name
+    assert_equal [@object['store']['Title Case']],
+                 JsonPath.new('$.store.Title Case').on(@object)
   end
 
   def test_dig_return_string
@@ -1252,6 +1257,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
       '@id' => 'http://example.org/store/42',
       '$meta-data' => 'whatevs',
       'Übermorgen' => 'The day after tomorrow',
+      'Title Case' => 'A title case string',
       '_links' => { 'self' => {} }
     } }
   end


### PR DESCRIPTION
see: https://ruby-doc.org/3.0.6/Regexp.html#class-Regexp-label-Character+Properties

fixes joshbuddy/jsonpath#163