### PR TITLE
#162 : symbolize_keys option doesn't work as the README says

### DIFF
--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -80,7 +80,7 @@ class JsonPath
 
   def on(obj_or_str, opts = {})
     a = enum_on(obj_or_str).to_a
-    if opts[:symbolize_keys]
+    if symbolize_keys?(opts)
       a.map! do |e|
         e.each_with_object({}) { |(k, v), memo| memo[k.to_sym] = v; }
       end
@@ -152,5 +152,9 @@ class JsonPath
   def set_max_nesting
     return unless @opts[:max_nesting].is_a?(Integer) && @opts[:max_nesting] > MAX_NESTING_ALLOWED
     @opts[:max_nesting] = false
+  end
+
+  def symbolize_keys?(opts)
+    opts.fetch(:symbolize_keys, @opts&.dig(:symbolize_keys))
   end
 end

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -1314,7 +1314,7 @@ class TestJsonpath < MiniTest::Unit::TestCase
   end
 
   def test_symbolize_key
-    data = { "store" => { "book" => [{"category" => "test"}]}}
+    data = { "store" => { "book" => [{"category" => "reference"}]}}
     assert_equal [{"category": "reference"}],  JsonPath.new('$..book[0]', symbolize_keys: true).on(data)
     assert_equal [{"category": "reference"}],  JsonPath.new('$..book[0]').on(data, symbolize_keys: true)
   end

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -1312,4 +1312,10 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal ["success"],  JsonPath.on(json, "$.test.$")
     assert_equal ["123"],  JsonPath.on(json, "$.test.a")
   end
+
+  def test_symbolize_key
+    data = { "store" => { "book" => [{"category" => "test"}]}}
+    assert_equal [{"category": "reference"}],  JsonPath.new('$..book[0]', symbolize_keys: true).on(data)
+    assert_equal [{"category": "reference"}],  JsonPath.new('$..book[0]').on(data, symbolize_keys: true)
+  end
 end


### PR DESCRIPTION
Currently it uses a symbolize_keys send in the on options, and ignore if its sent during the initialization.
So in this PR using this params send during initialization as fallback option.

Means first checking if _**on**_  params has symbolize_keys, else checking in opts send during the initialization.