### PR TITLE
Use 'Minitest' instead of deprecated 'MiniTest' casestyle

### DIFF
--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -5,7 +5,7 @@ require 'phocus'
 require 'jsonpath'
 require 'json'
 
-class TestJsonpath < MiniTest::Unit::TestCase
+class TestJsonpath < Minitest::Unit::TestCase
   def setup
     @object = example_object
     @object2 = example_object

--- a/test/test_jsonpath_bin.rb
+++ b/test/test_jsonpath_bin.rb
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require 'phocus'
 require 'jsonpath'
 
-class TestJsonpathBin < MiniTest::Unit::TestCase
+class TestJsonpathBin < Minitest::Unit::TestCase
   def setup
     @runner = 'ruby -Ilib bin/jsonpath'
     @original_dir = Dir.pwd

--- a/test/test_readme.rb
+++ b/test/test_readme.rb
@@ -5,7 +5,7 @@ require 'phocus'
 require 'jsonpath'
 require 'json'
 
-class TestJsonpathReadme < MiniTest::Unit::TestCase
+class TestJsonpathReadme < Minitest::Unit::TestCase
 
   def setup
     @json = <<-HERE_DOC


### PR DESCRIPTION
The version of minitest shipped with ruby3.3 yields an error with the old namespace 'MiniTest'. This change proposes to replace to the  'Minitest' convention.