### PR TITLE
Fix the case when a json key has a dot in it

### DIFF
--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -115,11 +115,11 @@ class JsonPath
 
   def self.construct_path(table_row)
     if table_row[:index]
-      table_row[:root_key] + "[" + table_row[:index].to_s + "]"
+      "#{table_row[:root_key]}[#{table_row[:index].to_s}]"
     else
       table_row_key = table_row[:key].include?(".") ? "'#{table_row[:key]}'" : table_row[:key]
 
-      table_row[:root_key] + "." + table_row_key
+      "#{table_row[:root_key]}.#{table_row_key}"
     end
   end
 

--- a/lib/jsonpath.rb
+++ b/lib/jsonpath.rb
@@ -115,9 +115,11 @@ class JsonPath
 
   def self.construct_path(table_row)
     if table_row[:index]
-      return table_row[:root_key] + '['+ table_row[:index].to_s + ']'
+      table_row[:root_key] + "[" + table_row[:index].to_s + "]"
     else
-      return table_row[:root_key] + '.'+ table_row[:key]
+      table_row_key = table_row[:key].include?(".") ? "'#{table_row[:key]}'" : table_row[:key]
+
+      table_row[:root_key] + "." + table_row_key
     end
   end
 

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -1295,15 +1295,17 @@ class TestJsonpath < MiniTest::Unit::TestCase
     data = {
       "foo" => nil,
       "bar" => {
-        "baz" => nil
+        "baz" => nil,
+        "baz.foo" => 3
       },
       "bars" => [
         { "foo" => 12 },
         { "foo" => nil },
+        { "foo.baz" => 3 },
         { }
       ]
     }
-    assert_equal ["$", "$.foo", "$.bar", "$.bar.baz", "$.bars", "$.bars[0].foo", "$.bars[0]", "$.bars[1].foo", "$.bars[1]", "$.bars[2]"], JsonPath.fetch_all_path(data)
+    assert_equal ["$", "$.foo", "$.bar", "$.bar.baz", "$.bar.'baz.foo'", "$.bars", "$.bars[0].foo", "$.bars[0]", "$.bars[1].foo", "$.bars[1]", "$.bars[2].'foo.baz'", "$.bars[2]", "$.bars[3]"], JsonPath.fetch_all_path(data)
   end
 
 

--- a/test/test_jsonpath.rb
+++ b/test/test_jsonpath.rb
@@ -1044,6 +1044,22 @@ class TestJsonpath < MiniTest::Unit::TestCase
     assert_equal [{ 'category' => 'reference', 'author' => 'Nigel Rees' }, { 'category' => 'fiction', 'author' => 'Evelyn Waugh' }], JsonPath.on(json, '$.store.book[*](category,author)')
   end
 
+  def test_selecting_key_with_a_dot_in_it
+    json = '
+    {
+      "foo.bar": {
+        "baz": 3
+      },
+      "baz.bar": {
+        "foo.bar": "baz"
+      }
+    }
+    '.to_json
+
+    assert_equal [{ 'baz' => 3 }], JsonPath.on(json, '$.\'foo.bar\'')
+    assert_equal ["baz"], JsonPath.on(json, '$.\'baz.bar\'.\'foo.bar\'')
+  end
+
   def test_selecting_multiple_keys_on_array_with_filter
     json = '
     {


### PR DESCRIPTION
With the current implementation `self.construct_path` returns the path `$.foo.bar` for the only key in the below hash.

```ruby
{
    "foo.bar": 3
}
```

But the path should actually be `$.'foo.bar'`.